### PR TITLE
Fix the charset hack for translations

### DIFF
--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -15,7 +15,9 @@ tasks:
     desc: "Extract translatable strings from Python files into a .pot template"
     cmds:
       - find {{ .TRANSLATION_SOURCE_DIRS | join " " }} -name '*.py' | xargs xgettext --package-name="Suffering Footprint" --package-version="0.1.0" --from-code=UTF-8 -o {{ .LOCALES_DIR }}/messages.pot -L Python
-    silent: false
+      - python {{ .LOCALES_DIR }}/fix_pot_charset.py {{ .LOCALES_DIR }}/messages.pot
+      - echo "✅ All strings extracted !"
+    silent: true
 
   translations-update:
     desc: "Update .po files for all languages"
@@ -29,7 +31,8 @@ tasks:
             msginit -l $lang -o {{ .LOCALES_DIR }}/$lang/LC_MESSAGES/messages.po -i {{ .LOCALES_DIR }}/messages.pot --no-translator
           fi
         done
-    silent: false
+      - echo "✅ All .po files updated !"
+    silent: true
 
   translations-compile:
     desc: "Compile .po files into .mo files"
@@ -38,7 +41,8 @@ tasks:
         for lang in {{ .TRANSLATION_LANGUAGES | join " " }}; do
           msgfmt -o {{ .LOCALES_DIR }}/$lang/LC_MESSAGES/messages.mo {{ .LOCALES_DIR }}/$lang/LC_MESSAGES/messages.po
         done
-    silent: false
+      - echo "✅ All .mo files compiled !"
+    silent: true
 
   translations-all:
     desc: "Run all tasks: extract, update, and compile"

--- a/backend/app/api/open_food_facts/routes.py
+++ b/backend/app/api/open_food_facts/routes.py
@@ -24,9 +24,6 @@ async def knowledge_panel(
 
     _ = request.state.translator
 
-    # TODO: fix this. Fake translation with utf8 encoding to force utf8 encoding in the generated translations files
-    _("ignøre this but keep it in the file")
-
     try:
         folksonomy_properties = get_properties_from_folksonomy(product_id)
     except ProductNotFoundException as e:

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 16:54+0100\n"
+"POT-Creation-Date: 2025-02-22 15:12+0100\n"
 "PO-Revision-Date: 2025-02-17 20:34+0100\n"
 "Last-Translator: Mathis Dupuy <mathis@macbook-air-de-mathis.local>\n"
 "Language-Team: English\n"
@@ -17,19 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/api/open_food_facts/routes.py:28
-msgid "ignøre this but keep it in the file"
-msgstr ""
-
-#: app/api/open_food_facts/routes.py:33
+#: app/api/open_food_facts/routes.py:30
 msgid "Product not found"
 msgstr ""
 
-#: app/api/open_food_facts/routes.py:36
+#: app/api/open_food_facts/routes.py:33
 msgid "Suffering Footprint"
 msgstr ""
 
-#: app/api/open_food_facts/routes.py:37
+#: app/api/open_food_facts/routes.py:34
 #, python-format
 msgid "The suffering footprint for this product is %s."
 msgstr ""

--- a/backend/app/locales/fix_pot_charset.py
+++ b/backend/app/locales/fix_pot_charset.py
@@ -1,0 +1,26 @@
+import sys
+
+
+def fix_charset_in_pot(file_path):
+    """Replaces the charset in a .pot file"""
+    old_string = '"Content-Type: text/plain; charset=CHARSET\\n"'
+    new_string = '"Content-Type: text/plain; charset=UTF-8\\n"'
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for i, line in enumerate(lines):
+        if line.strip() == old_string:
+            lines[i] = new_string + "\n"
+            break
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python fix_pot_charset.py <file.pot>")
+        sys.exit(1)
+
+    fix_charset_in_pot(sys.argv[1])
+    print(f"Charset updated in {sys.argv[1]}")

--- a/backend/app/locales/fr/LC_MESSAGES/messages.po
+++ b/backend/app/locales/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 16:54+0100\n"
+"POT-Creation-Date: 2025-02-22 15:12+0100\n"
 "PO-Revision-Date: 2025-02-17 20:32+0100\n"
 "Last-Translator: Mathis Dupuy <1292785+Akiat@users.noreply.github.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -17,19 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: app/api/open_food_facts/routes.py:28
-msgid "ignøre this but keep it in the file"
-msgstr ""
-
-#: app/api/open_food_facts/routes.py:33
+#: app/api/open_food_facts/routes.py:30
 msgid "Product not found"
 msgstr "Produit non trouvé"
 
-#: app/api/open_food_facts/routes.py:36
+#: app/api/open_food_facts/routes.py:33
 msgid "Suffering Footprint"
 msgstr "Empreinte Souffrance"
 
-#: app/api/open_food_facts/routes.py:37
+#: app/api/open_food_facts/routes.py:34
 #, python-format
 msgid "The suffering footprint for this product is %s."
 msgstr "L'empreinte souffrance pour ce produit est %s."


### PR DESCRIPTION
## Description  

This PR removes the need to have a UTF-8 translated string in the codebase to enforce a UTF-8 charset in the POT file.  

Instead, it introduces a script that directly replaces the charset in the POT file.  

## Changes  

- Added a script to correct the charset in the POT file.  
- Updated the `Taskfile` to integrate the new script.  
- Removed the hardcoded UTF-8 string from the codebase.  

## How to test  

Run the following command:  

```sh
task translation-all
```

Then, verify that the generated POT file contains:

```
Content-Type: text/plain; charset=UTF-8\n
```

instead of:

```
Content-Type: text/plain; charset=CHARSET\n
```