### PR TITLE
Create a demo page that simulates how a knowledge panel will be displayed on OFF

### DIFF
--- a/backend/app/api/open_food_facts/routes.py
+++ b/backend/app/api/open_food_facts/routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from starlette.requests import Request
 
-from app.business.open_food_facts.knowledge_panel import compute_suffering_footprint
+from app.business.open_food_facts.knowledge_panel import compute_suffering_footprint, get_knowledge_panel_response
 from app.config.exceptions import ExternalServiceException, ResourceNotFoundException
 from app.config.logging import setup_logging
 from app.schemas.open_food_facts.internal import KnowledgePanelResponse
@@ -30,6 +30,4 @@ async def knowledge_panel(request: Request, barcode: str):
         # Will be handled by the middleware, no need for additional processing here
         raise
 
-    return KnowledgePanelResponse(
-        pain_report=pain_report,
-    )
+    return get_knowledge_panel_response(pain_report=pain_report)

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -1,22 +1,24 @@
 import logging
-from random import randint
-from typing import List
 
 import httpx
-from pydantic import ValidationError
+from pydantic import HttpUrl, ValidationError
 
+from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import ResourceNotFoundException
 from app.enums.open_food_facts.enums import (
-    TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE,
-    TIME_IN_PAIN_FOR_100G_IN_SECONDS,
-    PainType,
+    AnimalType,
+    LayingHenBreedingType,
 )
 from app.schemas.open_food_facts.external import ProductData, ProductResponse
 from app.schemas.open_food_facts.internal import (
-    AnimalPainDuration,
     BreedingTypeAndWeight,
-    PainCategory,
+    Element,
+    KnowledgePanelResponse,
     PainReport,
+    Panel,
+    PanelElement,
+    TextElement,
+    TitleElement,
 )
 
 logger = logging.getLogger("app")
@@ -61,133 +63,7 @@ async def get_data_from_off(barcode: str) -> ProductData:
     return product_data
 
 
-class PainReportCalculator:
-    """
-    Class to calculate the pain report for an animal product.
-    """
-
-    def __init__(self, product_data: ProductData):
-        """
-        Initialize the calculator with product data.
-
-        Args:
-            product_data: ProductData instance containing categories_tags and labels_tags.
-        """
-        self.product_data = product_data
-        self.breeding_types_with_weights = self._compute_breeding_types_with_weights()
-
-    def _compute_breeding_types_with_weights(self) -> List[BreedingTypeAndWeight]:
-        """
-        Compute the breeding types and weights from product data.
-
-        Returns:
-            A list of BreedingTypeAndWeight objects (one by type of animal) with detected breeding types and weights
-        """
-
-        # Get the breeding types
-        breeding_types = self._get_breeding_types()
-
-        # Fill the weight for each breeding type and remove breeding types with weight <= 0
-        breeding_types_with_weights = self._get_breeding_types_with_weights(breeding_types)
-
-        return breeding_types_with_weights
-
-    def _get_breeding_types(self) -> List[BreedingTypeAndWeight]:
-        """
-        Compute the breeding types from product data.
-
-        Returns:
-            A list of BreedingTypeAndWeight objects (one by type of animal) with detected breeding types
-        """
-        breeding_types = []
-
-        # TODO test qui check que tous les type de breeding présents dans TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE
-        #  sont autorisés dans AnimalBreedingType.breeding_type
-        for animal_type, tags_by_breeding_type in TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE.items():
-            # Example of what we get from the for loop:
-            # animal_type: AnimalType.LAYING_HEN
-            # tags_by_breeding_type: LayingHenBreedingType.FURNISHED_CAGE: ["en:cage-chicken-eggs"]
-
-            for breeding_type, tags in tags_by_breeding_type.items():
-                if any(tag in self.product_data.categories_tags for tag in tags):
-                    # set the breeding type if any of the tags is present
-                    breeding_types.append(BreedingTypeAndWeight(animal_type=animal_type, breeding_type=breeding_type))
-                    break
-
-        return breeding_types
-
-    def _get_breeding_types_with_weights(self, breeding_types: List[BreedingTypeAndWeight]) -> List[BreedingTypeAndWeight]:
-        """
-        Compute the weight of animal product and fill the weight for each BreedingTypeAndWeight objects.
-        If the computed weight is <= 0, the BreedingTypeAndWeight object will not be returned.
-
-        Returns:
-            A list of BreedingTypeAndWeight objects (one by type of animal) with detected weights, if the weight is > 0
-        """
-        breeding_types_and_weights = []
-        for breeding_type in breeding_types:
-            # TODO: Implement actual weight calculation based on product data
-            #  This is currently a placeholder
-            weight = randint(0, 1000)
-
-            # We only return breeding types (and their weights) if the weight of the animal-based product is > 0
-            if weight > 0:
-                breeding_type.animal_product_weight = weight
-                breeding_types_and_weights.append(breeding_type)
-
-        return breeding_types_and_weights
-
-    def get_pain_report(self) -> PainReport:
-        """
-        Generate a pain report based on breeding types and weights.
-
-        Returns:
-            A complete pain report
-        """
-        if not self.breeding_types_with_weights:
-            raise ResourceNotFoundException("Can't find valid breeding type or animal product weight for this product")
-
-        return PainReport(
-            breeding_types_with_weights=self.breeding_types_with_weights,
-            pain_categories=[
-                PainCategory(
-                    pain_type=pain_type,
-                    animals=[
-                        AnimalPainDuration(
-                            animal_type=breeding_type_with_weight.animal_type,
-                            seconds_in_pain=self._calculate_time_in_pain(breeding_type_with_weight, pain_type)
-                        )
-                        for breeding_type_with_weight in self.breeding_types_with_weights
-                    ]
-                )
-                for pain_type in PainType
-            ],
-        )
-
-    def _calculate_time_in_pain(self, breeding_type_with_weight: BreedingTypeAndWeight, pain_type) -> int:
-        """
-        Calculates time in pain for a given combination.
-
-        Args:
-            breeding_type_with_weight: A BreedingTypeAndWeight object
-            pain_type: Type of pain (from PainType enum)
-
-        Returns:
-            Duration of pain in seconds
-        """
-        if breeding_type_with_weight.animal_product_weight <= 0:
-            return 0
-
-        time_in_pain = (
-            TIME_IN_PAIN_FOR_100G_IN_SECONDS.get(breeding_type_with_weight.animal_type, {})
-            .get(breeding_type_with_weight.breeding_type, {})
-            .get(pain_type, 0)
-        )
-
-        return int(time_in_pain * breeding_type_with_weight.animal_product_weight / 100)
-
-
-async def compute_suffering_footprint(barcode: str) -> PainReport | None:
+async def compute_suffering_footprint(barcode: str) -> PainReport:
     """
     Compute the suffering footprint for a product based on its barcode.
 
@@ -205,3 +81,194 @@ async def compute_suffering_footprint(barcode: str) -> PainReport | None:
 
     # Generate and return the pain report
     return calculator.get_pain_report()
+
+
+def get_knowledge_panel_response(pain_report: PainReport) -> KnowledgePanelResponse:
+    return KnowledgePanelResponse(
+        panels={
+            "main": create_main_panel(pain_report),
+            "intensities_definitions": create_intensities_definitions_panel(),
+            "physical_pain": create_physical_pain_panel(pain_report),
+            "psychological_pain": create_psychological_pain_panel(pain_report)
+        }
+    )
+
+
+def create_main_panel(pain_report: PainReport) -> Panel:
+    elements = [
+        get_text_element((
+            "L'<a href=\"https://empreinte-souffrance.org/\">empreinte Souffrance</a> "
+            "est calculée à partir des travaux de recherche du <a href=\"https://welfarefootprint.org/\">"
+            "Welfare Footprint Institute</a>."
+        )),
+        get_text_element((
+            "Le score et les détails exposés ci-dessous sont basés sur les données suivantes "
+            "(renseignées par la communauté d'Open Food Facts):"
+        ))]
+
+    for breeding_type_with_weight in pain_report.breeding_types_with_weights:
+        elements.append(get_text_element(text=generate_breeding_type_html(breeding_type_with_weight)))
+
+    elements.extend([
+        Element(element_type="panel", panel_element=PanelElement(panel_id="intensities_definitions")),
+        Element(element_type="panel", panel_element=PanelElement(panel_id="physical_pain")),
+        Element(element_type="panel", panel_element=PanelElement(panel_id="psychological_pain")),
+    ])
+
+    return Panel(
+        elements=elements,
+        level="info",
+        title_element=TitleElement(
+            grade="c",
+            icon_url=HttpUrl("https://iili.io/3o05WOX.png"),
+            name="suffering-footprint",
+            subtitle="Qu’est-ce que l’empreinte souffrance ?",
+            title="Empreinte souffrance",
+            type="grade"
+        ),
+        topics=["suffering-footprint"]
+    )
+
+
+def create_intensities_definitions_panel() -> Panel:
+    return Panel(
+        elements=[
+            get_text_element((
+                "<b>Inconfort</b> : Désagrément perceptible mais pouvant être ignoré. "
+                "N'interfère pas avec les activités quotidiennes ou les comportements motivés "
+                "(exploration, confort, entretien). Absence d'expressions visibles de douleur "
+                "et de perturbations physiologiques."
+            )),
+            get_text_element((
+                "<b>Douleur</b> : Douleur persistante avec possibilité de brefs moments d'oubli lors de "
+                "distractions. Réduit la fréquence des comportements motivés et altère partiellement les "
+                "capacités fonctionnelles, tout en permettant la réalisation des activités essentielles."
+            )),
+            get_text_element((
+                "<b>Souffrance</b> : Douleur constante qui prend priorité sur la plupart des comportements. "
+                "Empêche le bien-être positif et modifie drastiquement le niveau d'activité. "
+                "Requiert des analgésiques plus puissants et provoque une inattention à l'environnement."
+            )),
+            get_text_element((
+                "<b>Agonie</b> : Douleur extrême intolérable, même brièvement. "
+                "Chez les humains, marquerait le seuil de souffrance sous lequel beaucoup de personnes choisissent "
+                "de mettre fin à leurs jours plutôt que de l'endurer. Déclenche des manifestations involontaires "
+                "(cris, tremblements, agitation extrême) et ne peut être soulagée."
+            )),
+        ],
+        level="info",
+        title_element=TitleElement(
+            grade="c",
+            subtitle="Mieux comprendre les intensités de souffrance",
+            title="Définitions des niveaux d'intensité",
+            type="grade"
+        ),
+        topics=["suffering-footprint"]
+    )
+
+
+def create_physical_pain_panel(pain_report) -> Panel:
+    return Panel(
+        elements=[
+            get_text_element((
+                "Vous pouvez retrouver le détail (fractures, plaies...) "
+                "<a href=\"https://empreinte-souffrance.org/\">sur notre site</a>."
+            )),
+            get_text_element(_generate_html_items_for_pain_report(pain_report))
+        ],
+        level="info",
+        title_element=TitleElement(
+            grade="c",
+            name="physical-pain",
+            title="Douleur physique",
+            type="grade"
+        ),
+        topics=["suffering-footprint"]
+    )
+
+
+def create_psychological_pain_panel(pain_report) -> Panel:
+    return Panel(
+        elements=[
+            get_text_element((
+                "Vous pouvez retrouver le détail (Impossibilité de couver...) "
+                "<a href=\"https://empreinte-souffrance.org/\">sur notre site</a>."
+            )),
+            get_text_element(_generate_html_items_for_pain_report(pain_report))
+        ],
+        level="info",
+        title_element=TitleElement(
+            grade="c",
+            name="psychological-pain",
+            title="Douleur psychologique",
+            type="grade"
+        ),
+        topics=["suffering-footprint"]
+    )
+
+
+def get_text_element(text: str) -> Element:
+    return Element(element_type="text", text_element=TextElement(html=text))
+
+
+def get_breeding_type_mapping() -> dict:
+    return {
+        LayingHenBreedingType.CONVENTIONAL_CAGE: "Cage conventionnelle",
+        LayingHenBreedingType.FURNISHED_CAGE: "Cage améliorée",
+        LayingHenBreedingType.BARN: "Au sol",
+        LayingHenBreedingType.FREE_RANGE: "En plein air"
+    }
+
+
+def get_animal_type_mapping() -> dict:
+    return {
+        AnimalType.LAYING_HEN: "Poule pondeuse",
+        AnimalType.BROILER_CHICKEN: "Poulet de chair"
+    }
+
+
+def generate_breeding_type_html(breeding_type_with_weight: BreedingTypeAndWeight) -> str:
+    breeding_type_mapping = get_breeding_type_mapping()
+    animal_type_mapping = get_animal_type_mapping()
+    return (
+        f"<b>{animal_type_mapping[breeding_type_with_weight.animal_type]} :</b>\n"
+        f"<ul><li>Type d’élevage : <b>{breeding_type_mapping[breeding_type_with_weight.breeding_type]}</b></li>\n"
+        f"<li>Quantité d’oeuf dans le produit : <b>{breeding_type_with_weight.animal_product_weight}g</b></li></ul>"
+    )
+
+
+def _format_duration(seconds: int) -> str:
+    minutes, sec = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    parts = []
+    if days:
+        parts.append(f"{days} jours")
+    if hours:
+        parts.append(f"{hours} heures")
+    if minutes:
+        parts.append(f"{minutes} minutes")
+    if sec:
+        parts.append(f"{sec} secondes")
+    return " ".join(parts)
+
+
+def _generate_html_items_for_pain_report(pain_report: PainReport) -> str:
+    pain_labels = {
+        "EXCRUCIATING": "Agonie",
+        "DISABLING": "Souffrance",
+        "HURTFUL": "Douleur",
+        "ANNOYING": "Inconfort"
+    }
+
+    pain_durations = {
+        category.pain_intensity.name: sum(animal.seconds_in_pain for animal in category.animals)
+        for category in pain_report.pain_categories
+    }
+
+    html = "<ul>" + "".join(
+        f"<li><b>{pain_labels.get(pain_intensity, pain_intensity)}</b> : {_format_duration(duration)}</li>"
+        for pain_intensity, duration in sorted(pain_durations.items(), key=lambda x: x[1], reverse=True)
+    ) + "</ul>"
+
+    return html

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -5,12 +5,10 @@ from pydantic import HttpUrl, ValidationError
 
 from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import ResourceNotFoundException
-from app.enums.open_food_facts.enums import (
-    AnimalType,
-    LayingHenBreedingType,
-)
+from app.enums.open_food_facts.enums import AnimalType, PainType
 from app.schemas.open_food_facts.external import ProductData, ProductResponse
 from app.schemas.open_food_facts.internal import (
+    AnimalPainReport,
     BreedingTypeAndWeight,
     Element,
     KnowledgePanelResponse,
@@ -84,191 +82,363 @@ async def compute_suffering_footprint(barcode: str) -> PainReport:
 
 
 def get_knowledge_panel_response(pain_report: PainReport) -> KnowledgePanelResponse:
-    return KnowledgePanelResponse(
-        panels={
-            "main": create_main_panel(pain_report),
-            "intensities_definitions": create_intensities_definitions_panel(),
-            "physical_pain": create_physical_pain_panel(pain_report),
-            "psychological_pain": create_psychological_pain_panel(pain_report)
-        }
-    )
+    """
+    Create a complete knowledge panel response with all panels related to suffering footprint.
+    
+    Args:
+        pain_report: The pain report containing all animal data and pain durations
+        
+    Returns:
+        A complete KnowledgePanelResponse containing main panel, intensity definitions,
+        physical pain data and psychological pain data
+    """
+    panel_generator = KnowledgePanelGenerator(pain_report)
+    return panel_generator.get_response()
 
 
-def create_main_panel(pain_report: PainReport) -> Panel:
-    elements = [
-        get_text_element((
-            "L'<a href=\"https://empreinte-souffrance.org/\">empreinte Souffrance</a> "
-            "est calculée à partir des travaux de recherche du <a href=\"https://welfarefootprint.org/\">"
-            "Welfare Footprint Institute</a>."
-        )),
-        get_text_element((
-            "Le score et les détails exposés ci-dessous sont basés sur les données suivantes "
-            "(renseignées par la communauté d'Open Food Facts):"
-        ))]
-
-    for breeding_type_with_weight in pain_report.breeding_types_with_weights:
-        elements.append(get_text_element(text=generate_breeding_type_html(breeding_type_with_weight)))
-
-    elements.extend([
-        Element(element_type="panel", panel_element=PanelElement(panel_id="intensities_definitions")),
-        Element(element_type="panel", panel_element=PanelElement(panel_id="physical_pain")),
-        Element(element_type="panel", panel_element=PanelElement(panel_id="psychological_pain")),
-    ])
-
-    return Panel(
-        elements=elements,
-        level="info",
-        title_element=TitleElement(
-            grade="c",
-            icon_url=HttpUrl("https://iili.io/3o05WOX.png"),
-            name="suffering-footprint",
-            subtitle="Qu’est-ce que l’empreinte souffrance ?",
-            title="Empreinte souffrance",
-            type="grade"
-        ),
-        topics=["suffering-footprint"]
-    )
-
-
-def create_intensities_definitions_panel() -> Panel:
-    return Panel(
-        elements=[
-            get_text_element((
-                "<b>Inconfort</b> : Désagrément perceptible mais pouvant être ignoré. "
-                "N'interfère pas avec les activités quotidiennes ou les comportements motivés "
-                "(exploration, confort, entretien). Absence d'expressions visibles de douleur "
-                "et de perturbations physiologiques."
+class KnowledgePanelGenerator:
+    """
+    Class responsible for generating knowledge panel responses based on pain reports.
+    """
+    
+    def __init__(self, pain_report: PainReport):
+        """
+        Initialize the generator with a pain report.
+        
+        Args:
+            pain_report: The pain report containing animal data and pain durations
+        """
+        self.pain_report = pain_report
+    
+    def get_response(self) -> KnowledgePanelResponse:
+        """
+        Create a complete knowledge panel response with all suffering footprint panels.
+        
+        Returns:
+            A complete KnowledgePanelResponse with all necessary panels
+        """
+        return KnowledgePanelResponse(
+            panels={
+                "main": self.create_main_panel(),
+                "intensities_definitions": self.create_intensities_definitions_panel(),
+                "physical_pain": self.create_physical_pain_panel(),
+                "psychological_pain": self.create_psychological_pain_panel()
+            }
+        )
+    
+    def create_main_panel(self) -> Panel:
+        """
+        Create the main panel showing general information about the suffering footprint.
+        
+        This panel includes an explanation of the suffering footprint, the breeding
+        type and animal product weight information, and links to the other panels.
+        
+        Returns:
+            A panel with general information and links to detailed panels
+        """
+        elements = [
+            self._get_text_element((
+                "L'<a href='https://empreinte-souffrance.org/'>empreinte Souffrance</a> "
+                "est calculée à partir des travaux de recherche du <a href='https://welfarefootprint.org/'>"
+                "Welfare Footprint Institute</a>."
             )),
-            get_text_element((
-                "<b>Douleur</b> : Douleur persistante avec possibilité de brefs moments d'oubli lors de "
-                "distractions. Réduit la fréquence des comportements motivés et altère partiellement les "
-                "capacités fonctionnelles, tout en permettant la réalisation des activités essentielles."
-            )),
-            get_text_element((
-                "<b>Souffrance</b> : Douleur constante qui prend priorité sur la plupart des comportements. "
-                "Empêche le bien-être positif et modifie drastiquement le niveau d'activité. "
-                "Requiert des analgésiques plus puissants et provoque une inattention à l'environnement."
-            )),
-            get_text_element((
-                "<b>Agonie</b> : Douleur extrême intolérable, même brièvement. "
-                "Chez les humains, marquerait le seuil de souffrance sous lequel beaucoup de personnes choisissent "
-                "de mettre fin à leurs jours plutôt que de l'endurer. Déclenche des manifestations involontaires "
-                "(cris, tremblements, agitation extrême) et ne peut être soulagée."
-            )),
-        ],
-        level="info",
-        title_element=TitleElement(
-            grade="c",
-            subtitle="Mieux comprendre les intensités de souffrance",
-            title="Définitions des niveaux d'intensité",
-            type="grade"
-        ),
-        topics=["suffering-footprint"]
-    )
+            self._get_text_element((
+                "Le score et les détails exposés ci-dessous sont basés sur les données suivantes "
+                "(renseignées par la communauté d'Open Food Facts):"
+            ))]
 
+        for animal in self.pain_report.animals:
+            elements.append(
+                self._get_text_element(
+                    self._get_breeding_type_and_weight_html(animal.animal_type, animal.breeding_type_with_weight)
+                )
+            )
 
-def create_physical_pain_panel(pain_report) -> Panel:
-    return Panel(
-        elements=[
-            get_text_element((
-                "Vous pouvez retrouver le détail (fractures, plaies...) "
-                "<a href=\"https://empreinte-souffrance.org/\">sur notre site</a>."
-            )),
-            get_text_element(_generate_html_items_for_pain_report(pain_report))
-        ],
-        level="info",
-        title_element=TitleElement(
-            grade="c",
-            name="physical-pain",
-            title="Douleur physique",
-            type="grade"
-        ),
-        topics=["suffering-footprint"]
-    )
+        elements.extend([
+            Element(element_type="panel", panel_element=PanelElement(panel_id="intensities_definitions")),
+            Element(element_type="panel", panel_element=PanelElement(panel_id="physical_pain")),
+            Element(element_type="panel", panel_element=PanelElement(panel_id="psychological_pain")),
+        ])
 
+        return Panel(
+            elements=elements,
+            level="info",
+            title_element=TitleElement(
+                grade="c",
+                icon_url=HttpUrl("https://iili.io/3o05WOX.png"),
+                name="suffering-footprint",
+                subtitle="Qu'est-ce que l'empreinte souffrance ?",
+                title="Empreinte souffrance",
+                type="grade"
+            ),
+            topics=["suffering-footprint"]
+        )
 
-def create_psychological_pain_panel(pain_report) -> Panel:
-    return Panel(
-        elements=[
-            get_text_element((
-                "Vous pouvez retrouver le détail (Impossibilité de couver...) "
-                "<a href=\"https://empreinte-souffrance.org/\">sur notre site</a>."
-            )),
-            get_text_element(_generate_html_items_for_pain_report(pain_report))
-        ],
-        level="info",
-        title_element=TitleElement(
-            grade="c",
-            name="psychological-pain",
-            title="Douleur psychologique",
-            type="grade"
-        ),
-        topics=["suffering-footprint"]
-    )
+    def create_intensities_definitions_panel(self) -> Panel:
+        """
+        Create a panel explaining the different pain intensity levels.
+        
+        This panel provides detailed definitions for each pain intensity level:
+        Agonie (Excruciating), Souffrance (Disabling), Douleur (Hurtful), and Inconfort (Annoying).
+        The definitions help users understand the severity of each level.
+        
+        Returns:
+            A panel with definitions for each pain intensity level
+        """
+        return Panel(
+            elements=[
+                self._get_text_element((
+                    "<b>Agonie</b> : Douleur extrême intolérable, même brièvement. "
+                    "Chez les humains, marquerait le seuil de souffrance sous lequel beaucoup de personnes choisissent "
+                    "de mettre fin à leurs jours plutôt que de l'endurer. Déclenche des manifestations involontaires "
+                    "(cris, tremblements, agitation extrême) et ne peut être soulagée."
+                )),
+                self._get_text_element((
+                    "<b>Souffrance</b> : Douleur constante qui prend priorité sur la plupart des comportements. "
+                    "Empêche le bien-être positif et modifie drastiquement le niveau d'activité. "
+                    "Requiert des analgésiques plus puissants et provoque une inattention à l'environnement."
+                )),
+                self._get_text_element((
+                    "<b>Douleur</b> : Douleur persistante avec possibilité de brefs moments d'oubli lors de "
+                    "distractions. Réduit la fréquence des comportements motivés et altère partiellement les "
+                    "capacités fonctionnelles, tout en permettant la réalisation des activités essentielles."
+                )),
+                self._get_text_element((
+                    "<b>Inconfort</b> : Désagrément perceptible mais pouvant être ignoré. "
+                    "N'interfère pas avec les activités quotidiennes ou les comportements motivés "
+                    "(exploration, confort, entretien). Absence d'expressions visibles de douleur "
+                    "et de perturbations physiologiques."
+                )),
+            ],
+            level="info",
+            title_element=TitleElement(
+                grade="c",
+                subtitle="Mieux comprendre les intensités de souffrance",
+                title="Définitions des niveaux d'intensité",
+                type="grade"
+            ),
+            topics=["suffering-footprint"]
+        )
 
+    def get_animal_pain_for_panel(self, animal_type: AnimalType, pain_type: PainType) -> Element | None:
+        """
+        Create a text element with pain information for a specific animal and pain type.
+        
+        Args:
+            animal_type: The animal type to filter for
+            pain_type: The type of pain to display (physical or psychological)
+            
+        Returns:
+            A text element with the formatted HTML, or None if the animal has no data
+        """
+        # Find the animal in the pain report
+        animal_data = next((animal for animal in self.pain_report.animals if animal.animal_type == animal_type), None)
+        
+        if not animal_data:
+            return None
+            
+        # Generate HTML for this animal
+        animal_html = self._generate_animal_pain_html(animal_pain_report=animal_data, pain_type=pain_type)
 
-def get_text_element(text: str) -> Element:
-    return Element(element_type="text", text_element=TextElement(html=text))
+        # Return the text element
+        return self._get_text_element(animal_html)
 
+    def create_physical_pain_panel(self) -> Panel:
+        """
+        Create a panel displaying physical pain information by animal type.
+        
+        Returns:
+            A panel with physical pain information organized by animal
+        """
+        elements = [
+            self._get_text_element(
+                "La <b>douleur physique</b> comprend toutes les souffrances corporelles ressenties par les animaux: "
+                "fractures, plaies, maladies, difficultés respiratoires, etc."
+            ),
+            self._get_text_element(
+                "Les durées ci-dessous représentent le temps de souffrance causé par la production des ingrédients "
+                "d'origine animale dans ce produit:"
+            )
+        ]
+        
+        # Add each animal from the pain report
+        for animal in self.pain_report.animals:
+            animal_element = self.get_animal_pain_for_panel(animal.animal_type, PainType.PHYSICAL)
+            if animal_element:
+                elements.append(animal_element)
 
-def get_breeding_type_mapping() -> dict:
-    return {
-        LayingHenBreedingType.CONVENTIONAL_CAGE: "Cage conventionnelle",
-        LayingHenBreedingType.FURNISHED_CAGE: "Cage améliorée",
-        LayingHenBreedingType.BARN: "Au sol",
-        LayingHenBreedingType.FREE_RANGE: "En plein air"
-    }
+        # Add footer
+        elements.append(self._get_text_element(
+            "Vous pouvez retrouver plus de détails sur les différents types de souffrances physiques "
+            "<a href=\"https://empreinte-souffrance.org/\">sur notre site</a>."
+        ))
+        
+        return Panel(
+            elements=elements,
+            level="info",
+            title_element=TitleElement(
+                grade="c",
+                name="physical-pain",
+                title="Douleur physique",
+                type="grade"
+            ),
+            topics=["suffering-footprint"]
+        )
 
+    def create_psychological_pain_panel(self) -> Panel:
+        """
+        Create a panel displaying psychological pain information by animal type.
+        
+        Returns:
+            A panel with psychological pain information organized by animal
+        """
+        elements = [
+            self._get_text_element(
+                "La <b>douleur psychologique</b> comprend les souffrances mentales ressenties par les animaux: "
+                "stress, anxiété, impossibilité d'exprimer des comportements naturels, etc."
+            ),
+            self._get_text_element(
+                "Les durées ci-dessous représentent le temps de souffrance causé par la production des ingrédients "
+                "d'origine animale dans ce produit:"
+            )
+        ]
+        
+        # Add each animal from the pain report
+        for animal in self.pain_report.animals:
+            animal_element = self.get_animal_pain_for_panel(animal.animal_type, PainType.PSYCHOLOGICAL)
+            if animal_element:
+                elements.append(animal_element)
 
-def get_animal_type_mapping() -> dict:
-    return {
-        AnimalType.LAYING_HEN: "Poule pondeuse",
-        AnimalType.BROILER_CHICKEN: "Poulet de chair"
-    }
+        # Add footer
+        elements.append(self._get_text_element(
+            "Vous pouvez retrouver plus de détails sur les différents types de souffrances psychologiques "
+            "<a href=\"https://empreinte-souffrance.org/\">sur notre site</a>."
+        ))
+        
+        return Panel(
+            elements=elements,
+            level="info",
+            title_element=TitleElement(
+                grade="c",
+                name="psychological-pain",
+                title="Douleur psychologique",
+                type="grade"
+            ),
+            topics=["suffering-footprint"]
+        )
 
+    def _get_text_element(self, text: str) -> Element:
+        """
+        Create a text element with HTML content for use in a panel.
+        
+        Args:
+            text: The HTML content as a string
+            
+        Returns:
+            An Element object with the text content properly wrapped
+        """
+        return Element(element_type="text", text_element=TextElement(html=text))
 
-def generate_breeding_type_html(breeding_type_with_weight: BreedingTypeAndWeight) -> str:
-    breeding_type_mapping = get_breeding_type_mapping()
-    animal_type_mapping = get_animal_type_mapping()
-    return (
-        f"<b>{animal_type_mapping[breeding_type_with_weight.animal_type]} :</b>\n"
-        f"<ul><li>Type d’élevage : <b>{breeding_type_mapping[breeding_type_with_weight.breeding_type]}</b></li>\n"
-        f"<li>Quantité d’oeuf dans le produit : <b>{breeding_type_with_weight.animal_product_weight}g</b></li></ul>"
-    )
+    def _get_breeding_type_and_weight_html(self, animal_type: AnimalType, breeding_type_with_weight: BreedingTypeAndWeight) -> str:
+        """
+        Format animal type, breeding type and product weight information as HTML.
+        
+        Creates a formatted HTML string showing the animal type (e.g., "Poule pondeuse"),
+        the breeding type (e.g., "Cage conventionnelle"), and the weight of animal product
+        in the food item.
+        
+        Args:
+            animal_type: The type of animal (e.g., LAYING_HEN)
+            breeding_type_with_weight: Object containing the breeding type and weight data
+            
+        Returns:
+            Formatted HTML string with animal information
+        """
+        return (
+            f"<b>{animal_type.display_name} :</b>\n"
+            f"<ul><li>Type d'élevage : <b>{breeding_type_with_weight.breeding_type.display_name}</b></li>\n"
+            f"<li>Quantité d'oeuf dans le produit : <b>{breeding_type_with_weight.animal_product_weight}g</b></li></ul>"
+        )
 
+    def _format_duration(self, seconds: int) -> str:
+        """
+        Format a duration in seconds into a human-readable string.
+        
+        Converts seconds into a combination of days, hours, minutes and seconds
+        as appropriate.
+        
+        Args:
+            seconds: The duration in seconds to format
+            
+        Returns:
+            A formatted string like "2 days 5 hours 30 minutes 10 seconds"
+        """
+        if seconds <= 0:
+            return "0 seconde"
 
-def _format_duration(seconds: int) -> str:
-    minutes, sec = divmod(seconds, 60)
-    hours, minutes = divmod(minutes, 60)
-    days, hours = divmod(hours, 24)
-    parts = []
-    if days:
-        parts.append(f"{days} jours")
-    if hours:
-        parts.append(f"{hours} heures")
-    if minutes:
-        parts.append(f"{minutes} minutes")
-    if sec:
-        parts.append(f"{sec} secondes")
-    return " ".join(parts)
+        minutes, sec = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        days, hours = divmod(hours, 24)
+        parts = []
+        if days:
+            parts.append(f"{days} jours")
+        if hours:
+            parts.append(f"{hours} heures")
+        if minutes:
+            parts.append(f"{minutes} minutes")
+        if sec:
+            parts.append(f"{sec} secondes")
+        return " ".join(parts) if parts else "0 seconde"
 
+    def _generate_animal_pain_html(self, animal_pain_report: AnimalPainReport, pain_type: PainType) -> str:
+        """
+        Generate HTML for a single animal's pain levels of a specific type.
+        
+        Args:
+            animal_pain_report: The animal pain report containing all pain data
+            pain_type: Type of pain to filter by (physical or psychological)
+            
+        Returns:
+            HTML string for this animal's pain levels
+        """
+        # Get the pain levels for this pain_type for this animal (sorted by intensity)
+        pain_levels = animal_pain_report.get_pain_levels_by_type(pain_type)
 
-def _generate_html_items_for_pain_report(pain_report: PainReport) -> str:
-    pain_labels = {
-        "EXCRUCIATING": "Agonie",
-        "DISABLING": "Souffrance",
-        "HURTFUL": "Douleur",
-        "ANNOYING": "Inconfort"
-    }
+        # If no pain of this type, return empty string
+        if not pain_levels:
+            return ""
+            
+        # Start with animal name and breeding type
+        animal_type = animal_pain_report.animal_type
+        breeding_type = animal_pain_report.breeding_type_with_weight.breeding_type
+        html_parts = [f"<b>{animal_type.display_name} - {breeding_type.display_name}</b>"]
+        
+        # Add pain levels in standardized order
+        html_parts.append("<ul>")
+        for pain_level_data in pain_levels:
+            intensity_label = pain_level_data.pain_intensity.display_name
+            duration = self._format_duration(pain_level_data.seconds_in_pain)
 
-    pain_durations = {
-        category.pain_intensity.name: sum(animal.seconds_in_pain for animal in category.animals)
-        for category in pain_report.pain_categories
-    }
+            html_parts.append(f"<li><b>{intensity_label}</b> : {duration}</li>")
+        html_parts.append("</ul>")
+        
+        return "".join(html_parts)
 
-    html = "<ul>" + "".join(
-        f"<li><b>{pain_labels.get(pain_intensity, pain_intensity)}</b> : {_format_duration(duration)}</li>"
-        for pain_intensity, duration in sorted(pain_durations.items(), key=lambda x: x[1], reverse=True)
-    ) + "</ul>"
+    def _generate_html_items_for_pain_report(self, pain_type: PainType = None) -> str:
+        """
+        Generate HTML items showing pain durations for all animals with the specified pain type.
+        
+        Args:
+            pain_type: Filter for pain type (physical or psychological)
+            
+        Returns:
+            HTML string organized by animal and pain intensity
+        """
+        # Generate HTML for each animal
+        html_parts = []
+        for animal in self.pain_report.animals:
+            animal_html = self._generate_animal_pain_html(animal_pain_report=animal, pain_type=pain_type)
+            if animal_html:
+                html_parts.append(animal_html)
 
-    return html
+        return "".join(html_parts)

--- a/backend/app/business/open_food_facts/pain_report_calculator.py
+++ b/backend/app/business/open_food_facts/pain_report_calculator.py
@@ -1,0 +1,138 @@
+from random import randint
+from typing import List
+
+from app.config.exceptions import ResourceNotFoundException
+from app.enums.open_food_facts.enums import (
+    TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE,
+    TIME_IN_PAIN_FOR_100G_IN_SECONDS,
+    PainIntensity,
+)
+from app.schemas.open_food_facts.external import ProductData
+from app.schemas.open_food_facts.internal import AnimalPainDuration, BreedingTypeAndWeight, PainCategory, PainReport
+
+
+class PainReportCalculator:
+    """
+    Class to calculate the pain report for an animal product.
+    """
+
+    def __init__(self, product_data: ProductData):
+        """
+        Initialize the calculator with product data.
+
+        Args:
+            product_data: ProductData instance containing categories_tags and labels_tags.
+        """
+        self.product_data = product_data
+        self.breeding_types_with_weights = self._compute_breeding_types_with_weights()
+
+    def _compute_breeding_types_with_weights(self) -> List[BreedingTypeAndWeight]:
+        """
+        Compute the breeding types and weights from product data.
+
+        Returns:
+            A list of BreedingTypeAndWeight objects (one by type of animal) with detected breeding types and weights
+        """
+
+        # Get the breeding types
+        breeding_types = self._get_breeding_types()
+
+        # Fill the weight for each breeding type and remove breeding types with weight <= 0
+        breeding_types_with_weights = self._get_breeding_types_with_weights(breeding_types)
+
+        return breeding_types_with_weights
+
+    def _get_breeding_types(self) -> List[BreedingTypeAndWeight]:
+        """
+        Compute the breeding types from product data.
+
+        Returns:
+            A list of BreedingTypeAndWeight objects (one by type of animal) with detected breeding types
+        """
+        breeding_types = []
+        for animal_type, tags_by_breeding_type in TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE.items():
+            # Example of what we get from the for loop:
+            # animal_type: AnimalType.LAYING_HEN
+            # tags_by_breeding_type: LayingHenBreedingType.FURNISHED_CAGE: ["en:cage-chicken-eggs"]
+
+            for breeding_type, tags in tags_by_breeding_type.items():
+                if any(tag in self.product_data.categories_tags for tag in tags):
+                    # set the breeding type if any of the tags is present
+                    breeding_types.append(BreedingTypeAndWeight(animal_type=animal_type, breeding_type=breeding_type))
+                    break
+
+        return breeding_types
+
+    def _get_breeding_types_with_weights(self, breeding_types: List[BreedingTypeAndWeight]) -> List[BreedingTypeAndWeight]:
+        """
+        Compute the weight of animal product and fill the weight for each BreedingTypeAndWeight objects.
+        If the computed weight is <= 0, the BreedingTypeAndWeight object will not be returned.
+
+        Returns:
+            A list of BreedingTypeAndWeight objects (one by type of animal) with detected weights, if the weight is > 0
+        """
+        breeding_types_and_weights = []
+        for breeding_type in breeding_types:
+            # TODO: Implement actual weight calculation based on product data
+            #  This is currently a placeholder
+            weight = randint(0, 1000)
+
+            # We only return breeding types (and their weights) if the weight of the animal-based product is > 0
+            if weight > 0:
+                breeding_type.animal_product_weight = weight
+                breeding_types_and_weights.append(breeding_type)
+
+        return breeding_types_and_weights
+
+    def get_pain_report(self) -> PainReport:
+        """
+        Generate a pain report based on breeding types and weights.
+
+        Returns:
+            A complete pain report
+        """
+        if not self.breeding_types_with_weights:
+            raise ResourceNotFoundException("Can't find valid breeding type or animal product weight for this product")
+
+        return PainReport(
+            breeding_types_with_weights=self.breeding_types_with_weights,
+            pain_categories=[
+                PainCategory(
+                    pain_intensity=pain_intensity,
+                    animals=[
+                        AnimalPainDuration(
+                            animal_type=breeding_type_with_weight.animal_type,
+                            seconds_in_pain=self._calculate_time_in_pain(breeding_type_with_weight, pain_intensity)
+                        )
+                        for breeding_type_with_weight in self.breeding_types_with_weights
+                    ]
+                )
+                for pain_intensity in PainIntensity
+            ],
+        )
+
+    def _calculate_time_in_pain(
+            self,
+            breeding_type_with_weight: BreedingTypeAndWeight,
+            pain_intensity: PainIntensity
+    ) -> int:
+        """
+        Calculates time in pain for a given combination.
+
+        Args:
+            breeding_type_with_weight: A BreedingTypeAndWeight object
+            pain_intensity: Pain intensity (from PainIntensity enum)
+
+        Returns:
+            Duration of pain in seconds
+        """
+        if breeding_type_with_weight.animal_product_weight <= 0:
+            return 0
+
+        time_in_pain = (
+            TIME_IN_PAIN_FOR_100G_IN_SECONDS.get(breeding_type_with_weight.animal_type, {})
+            .get(breeding_type_with_weight.breeding_type, {})
+            .get(pain_intensity, 0)
+        )
+
+        return int(time_in_pain * breeding_type_with_weight.animal_product_weight / 100)

--- a/backend/app/business/open_food_facts/pain_report_calculator.py
+++ b/backend/app/business/open_food_facts/pain_report_calculator.py
@@ -1,14 +1,16 @@
 from random import randint
-from typing import List
+from typing import Dict, List
 
 from app.config.exceptions import ResourceNotFoundException
 from app.enums.open_food_facts.enums import (
     TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE,
     TIME_IN_PAIN_FOR_100G_IN_SECONDS,
+    AnimalType,
     PainIntensity,
+    PainType,
 )
 from app.schemas.open_food_facts.external import ProductData
-from app.schemas.open_food_facts.internal import AnimalPainDuration, BreedingTypeAndWeight, PainCategory, PainReport
+from app.schemas.open_food_facts.internal import AnimalPainReport, BreedingTypeAndWeight, PainLevelData, PainReport
 
 
 class PainReportCalculator:
@@ -25,68 +27,14 @@ class PainReportCalculator:
         """
         self.product_data = product_data
         self.breeding_types_with_weights = self._compute_breeding_types_with_weights()
-
-    def _compute_breeding_types_with_weights(self) -> List[BreedingTypeAndWeight]:
-        """
-        Compute the breeding types and weights from product data.
-
-        Returns:
-            A list of BreedingTypeAndWeight objects (one by type of animal) with detected breeding types and weights
-        """
-
-        # Get the breeding types
-        breeding_types = self._get_breeding_types()
-
-        # Fill the weight for each breeding type and remove breeding types with weight <= 0
-        breeding_types_with_weights = self._get_breeding_types_with_weights(breeding_types)
-
-        return breeding_types_with_weights
-
-    def _get_breeding_types(self) -> List[BreedingTypeAndWeight]:
-        """
-        Compute the breeding types from product data.
-
-        Returns:
-            A list of BreedingTypeAndWeight objects (one by type of animal) with detected breeding types
-        """
-        breeding_types = []
-        for animal_type, tags_by_breeding_type in TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE.items():
-            # Example of what we get from the for loop:
-            # animal_type: AnimalType.LAYING_HEN
-            # tags_by_breeding_type: LayingHenBreedingType.FURNISHED_CAGE: ["en:cage-chicken-eggs"]
-
-            for breeding_type, tags in tags_by_breeding_type.items():
-                if any(tag in self.product_data.categories_tags for tag in tags):
-                    # set the breeding type if any of the tags is present
-                    breeding_types.append(BreedingTypeAndWeight(animal_type=animal_type, breeding_type=breeding_type))
-                    break
-
-        return breeding_types
-
-    def _get_breeding_types_with_weights(self, breeding_types: List[BreedingTypeAndWeight]) -> List[BreedingTypeAndWeight]:
-        """
-        Compute the weight of animal product and fill the weight for each BreedingTypeAndWeight objects.
-        If the computed weight is <= 0, the BreedingTypeAndWeight object will not be returned.
-
-        Returns:
-            A list of BreedingTypeAndWeight objects (one by type of animal) with detected weights, if the weight is > 0
-        """
-        breeding_types_and_weights = []
-        for breeding_type in breeding_types:
-            # TODO: Implement actual weight calculation based on product data
-            #  This is currently a placeholder
-            weight = randint(0, 1000)
-
-            # We only return breeding types (and their weights) if the weight of the animal-based product is > 0
-            if weight > 0:
-                breeding_type.animal_product_weight = weight
-                breeding_types_and_weights.append(breeding_type)
-
-        return breeding_types_and_weights
-
+    
     def get_pain_report(self) -> PainReport:
         """
         Generate a pain report based on breeding types and weights.
+        
+        The report is organized by animal type, with each animal having
+        a list of pain levels categorized by pain type (physical/psychological)
+        and breeding type information.
 
         Returns:
             A complete pain report
@@ -94,33 +42,167 @@ class PainReportCalculator:
         if not self.breeding_types_with_weights:
             raise ResourceNotFoundException("Can't find valid breeding type or animal product weight for this product")
 
-        return PainReport(
-            breeding_types_with_weights=self.breeding_types_with_weights,
-            pain_categories=[
-                PainCategory(
-                    pain_intensity=pain_intensity,
-                    animals=[
-                        AnimalPainDuration(
-                            animal_type=breeding_type_with_weight.animal_type,
-                            seconds_in_pain=self._calculate_time_in_pain(breeding_type_with_weight, pain_intensity)
-                        )
-                        for breeding_type_with_weight in self.breeding_types_with_weights
-                    ]
+        animal_reports = []
+        
+        # Process each animal type and its breeding type
+        for animal_type, breeding_type in self.breeding_types_with_weights.items():
+            # Generate all pain levels for this animal
+            pain_levels = self._generate_pain_levels_for_animal(animal_type, breeding_type)
+            
+            # Add animal report to the list
+            animal_reports.append(
+                AnimalPainReport(
+                    animal_type=animal_type,
+                    pain_levels=pain_levels,
+                    breeding_type_with_weight=breeding_type
                 )
-                for pain_intensity in PainIntensity
-            ],
-        )
+            )
 
-    def _calculate_time_in_pain(
+        return PainReport(animals=animal_reports)
+
+    def _generate_pain_levels_for_animal(
             self,
+            animal_type: AnimalType,
+            breeding_type: BreedingTypeAndWeight
+    ) -> List[PainLevelData]:
+        """
+        Generate pain levels for a specific animal type and breeding type.
+
+        Args:
+            animal_type: The type of animal
+            breeding_type: The breeding type with weight information
+
+        Returns:
+            List of PainLevelData objects for all pain types and intensities
+        """
+        pain_levels = []
+
+        # Process each pain type
+        for pain_type in PainType:
+            pain_levels.extend(self._generate_pain_levels_for_type(
+                animal_type, breeding_type, pain_type
+            ))
+
+        return pain_levels
+
+    def _generate_pain_levels_for_type(
+            self,
+            animal_type: AnimalType,
+            breeding_type: BreedingTypeAndWeight,
+            pain_type: PainType
+    ) -> List[PainLevelData]:
+        """
+        Generate pain levels for a specific animal, breeding type, and pain type.
+
+        Args:
+            animal_type: The type of animal
+            breeding_type: The breeding type with weight information
+            pain_type: The type of pain (physical or psychological)
+
+        Returns:
+            List of PainLevelData objects for all pain intensities of the given type
+        """
+        pain_levels = []
+
+        # Process each pain intensity for this pain type
+        for pain_intensity in PainIntensity:
+            # Calculate seconds in pain for this animal, pain type, and intensity
+            seconds_in_pain = self._calculate_time_in_pain_for_animal_with_type(
+                animal_type,
+                breeding_type,
+                pain_type,
+                pain_intensity
+            )
+
+            # Add pain level entry
+            pain_levels.append(
+                PainLevelData(
+                    pain_intensity=pain_intensity,
+                    pain_type=pain_type,
+                    seconds_in_pain=seconds_in_pain
+                )
+            )
+
+        return pain_levels
+
+    def _compute_breeding_types_with_weights(self) -> Dict[AnimalType, BreedingTypeAndWeight]:
+        """
+        Compute the breeding types and weights from product data.
+
+        Returns:
+            A dictionary mapping animal types to BreedingTypeAndWeight objects with detected breeding type and weight
+        """
+
+        # Get the breeding types
+        breeding_types_by_animal = self._get_breeding_types()
+
+        # Fill the weight for each breeding type and remove breeding types with weight <= 0
+        breeding_types_with_weights = self._get_breeding_types_with_weights(breeding_types_by_animal)
+
+        return breeding_types_with_weights
+
+    def _get_breeding_types(self) -> Dict[AnimalType, BreedingTypeAndWeight]:
+        """
+        Compute the breeding types from product data.
+
+        Returns:
+            A dictionary mapping animal types to BreedingTypeAndWeight objects with detected breeding types
+        """
+        breeding_types_by_animal = {}
+        for animal_type, tags_by_breeding_type in TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE.items():
+            # Example of what we get from the for loop:
+            # animal_type: AnimalType.LAYING_HEN
+            # tags_by_breeding_type: LayingHenBreedingType.FURNISHED_CAGE: ["en:cage-chicken-eggs"]
+
+            for breeding_type, tags in tags_by_breeding_type.items():
+                if any(tag in self.product_data.categories_tags for tag in tags):
+                    # Set the breeding type if any of the tags is present
+                    breeding_types_by_animal[animal_type] = BreedingTypeAndWeight(breeding_type=breeding_type)
+                    break
+
+        return breeding_types_by_animal
+
+    def _get_breeding_types_with_weights(
+            self,
+            breeding_types_by_animal: Dict[AnimalType, BreedingTypeAndWeight]
+    ) -> Dict[AnimalType, BreedingTypeAndWeight]:
+        """
+        Compute the weight of animal product and fill the weight for each BreedingTypeAndWeight object.
+        If the computed weight is <= 0, the animal type will be removed from the dictionary.
+        
+        Args:
+            breeding_types_by_animal: Dictionary mapping animal types to BreedingTypeAndWeight objects
+
+        Returns:
+            A dictionary mapping animal types to BreedingTypeAndWeight objects with their weights, if the weight is > 0
+        """
+        breeding_types_with_weights = {}
+        for animal_type, breeding_type in breeding_types_by_animal.items():
+            # TODO: Implement actual weight calculation based on product data
+            #  This is currently a placeholder
+            weight = randint(0, 1000)
+
+            # We only return breeding types (and their weights) if the weight of the animal-based product is > 0
+            if weight > 0:
+                breeding_type.animal_product_weight = weight
+                breeding_types_with_weights[animal_type] = breeding_type
+
+        return breeding_types_with_weights
+
+    def _calculate_time_in_pain_for_animal_with_type(
+            self,
+            animal_type: AnimalType,
             breeding_type_with_weight: BreedingTypeAndWeight,
+            pain_type: PainType,
             pain_intensity: PainIntensity
     ) -> int:
         """
-        Calculates time in pain for a given combination.
+        Calculates time in pain for a given animal type, breeding type, pain type, and pain intensity.
 
         Args:
+            animal_type: The type of animal
             breeding_type_with_weight: A BreedingTypeAndWeight object
+            pain_type: The type of pain (physical or psychological)
             pain_intensity: Pain intensity (from PainIntensity enum)
 
         Returns:
@@ -129,10 +211,15 @@ class PainReportCalculator:
         if breeding_type_with_weight.animal_product_weight <= 0:
             return 0
 
-        time_in_pain = (
-            TIME_IN_PAIN_FOR_100G_IN_SECONDS.get(breeding_type_with_weight.animal_type, {})
-            .get(breeding_type_with_weight.breeding_type, {})
-            .get(pain_intensity, 0)
-        )
+        # Get the time in pain per 100g for this combination of parameters
+        # Default to 0 if any level in the hierarchy is missing
+        try:
+            breeding_type = breeding_type_with_weight.breeding_type
+            time_in_pain = TIME_IN_PAIN_FOR_100G_IN_SECONDS[animal_type][breeding_type][pain_type][pain_intensity]
+        except (KeyError, TypeError):
+            # This combination of animal, breeding type, pain type, and intensity is not defined
+            return 0
 
+        # Scale the time in pain based on the weight of animal product
         return int(time_in_pain * breeding_type_with_weight.animal_product_weight / 100)
+    

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -1,9 +1,9 @@
-from enum import StrEnum
+from enum import StrEnum, auto
 
 
 class AnimalType(StrEnum):
-    LAYING_HEN = "laying_hen"
-    BROILER_CHICKEN = "broiler_chicken"
+    LAYING_HEN = auto()
+    BROILER_CHICKEN = auto()
     
     @property
     def display_name(self) -> str:
@@ -16,10 +16,10 @@ class AnimalType(StrEnum):
 
 
 class LayingHenBreedingType(StrEnum):
-    CONVENTIONAL_CAGE = "conventional_cage"
-    FURNISHED_CAGE = "furnished_cage"
-    BARN = "barn"
-    FREE_RANGE = "free_range"
+    CONVENTIONAL_CAGE = auto()
+    FURNISHED_CAGE = auto()
+    BARN = auto()
+    FREE_RANGE = auto()
     
     @property
     def display_name(self) -> str:
@@ -34,7 +34,7 @@ class LayingHenBreedingType(StrEnum):
 
 
 class BroilerChickenBreedingType(StrEnum):
-    FREE_RANGE = "free_range"
+    FREE_RANGE = auto()
     
     @property
     def display_name(self) -> str:
@@ -46,10 +46,10 @@ class BroilerChickenBreedingType(StrEnum):
 
 
 class PainIntensity(StrEnum):
-    EXCRUCIATING = "excruciating"
-    DISABLING = "disabling"
-    HURTFUL = "hurtful"
-    ANNOYING = "annoying"
+    EXCRUCIATING = auto()
+    DISABLING = auto()
+    HURTFUL = auto()
+    ANNOYING = auto()
     
     @property
     def display_name(self) -> str:
@@ -69,8 +69,8 @@ class PainIntensity(StrEnum):
 
 
 class PainType(StrEnum):
-    PHYSICAL = "physical"
-    PSYCHOLOGICAL = "psychological"
+    PHYSICAL = auto()
+    PSYCHOLOGICAL = auto()
     
     @property
     def display_name(self) -> str:
@@ -135,7 +135,7 @@ TIME_IN_PAIN_FOR_100G_IN_SECONDS = {
                 PainIntensity.ANNOYING: 16000
             },
             PainType.PSYCHOLOGICAL: {
-                PainIntensity.EXCRUCIATING: 0,
+                PainIntensity.EXCRUCIATING: 1,
                 PainIntensity.DISABLING: 51,
                 PainIntensity.HURTFUL: 1222,
                 PainIntensity.ANNOYING: 17333

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -1,68 +1,161 @@
-from enum import StrEnum, auto
+from enum import StrEnum
 
 
 class AnimalType(StrEnum):
-    LAYING_HEN = auto()
-    BROILER_CHICKEN = auto()
+    LAYING_HEN = "laying_hen"
+    BROILER_CHICKEN = "broiler_chicken"
+    
+    @property
+    def display_name(self) -> str:
+        """Return the human-readable name for this animal type"""
+        mappings = {
+            "laying_hen": "Poule pondeuse",
+            "broiler_chicken": "Poulet de chair"
+        }
+        return mappings.get(self.value, self.value)
 
 
 class LayingHenBreedingType(StrEnum):
-    CONVENTIONAL_CAGE = auto()
-    FURNISHED_CAGE = auto()
-    BARN = auto()
-    FREE_RANGE = auto()
+    CONVENTIONAL_CAGE = "conventional_cage"
+    FURNISHED_CAGE = "furnished_cage"
+    BARN = "barn"
+    FREE_RANGE = "free_range"
+    
+    @property
+    def display_name(self) -> str:
+        """Return the human-readable name for this breeding type"""
+        mappings = {
+            "conventional_cage": "Cage conventionnelle",
+            "furnished_cage": "Cage améliorée",
+            "barn": "Au sol",
+            "free_range": "En plein air"
+        }
+        return mappings.get(self.value, self.value)
 
 
 class BroilerChickenBreedingType(StrEnum):
-    FREE_RANGE = auto()
+    FREE_RANGE = "free_range"
+    
+    @property
+    def display_name(self) -> str:
+        """Return the human-readable name for this breeding type"""
+        mappings = {
+            "free_range": "En plein air"
+        }
+        return mappings.get(self.value, self.value)
 
 
 class PainIntensity(StrEnum):
-    EXCRUCIATING = auto()
-    DISABLING = auto()
-    HURTFUL = auto()
-    ANNOYING = auto()
+    EXCRUCIATING = "excruciating"
+    DISABLING = "disabling"
+    HURTFUL = "hurtful"
+    ANNOYING = "annoying"
+    
+    @property
+    def display_name(self) -> str:
+        """Return the human-readable name for this pain intensity"""
+        mappings = {
+            "excruciating": "Agonie",
+            "disabling": "Souffrance",
+            "hurtful": "Douleur",
+            "annoying": "Inconfort"
+        }
+        return mappings.get(self.value, self.value)
+    
+    @classmethod
+    def get_intensity_order(cls) -> list["PainIntensity"]:
+        """Return the order of pain intensities from most to least severe."""
+        return [cls.EXCRUCIATING, cls.DISABLING, cls.HURTFUL, cls.ANNOYING]
 
 
 class PainType(StrEnum):
-    PHYSICAL = auto()
-    PSYCHOLOGICAL = auto()
+    PHYSICAL = "physical"
+    PSYCHOLOGICAL = "psychological"
+    
+    @property
+    def display_name(self) -> str:
+        """Return the human-readable name for this pain type"""
+        mappings = {
+            "physical": "Physique",
+            "psychological": "Psychologique"
+        }
+        return mappings.get(self.value, self.value)
 
 
-# Time in pain by animal type, per 100g, in seconds
+# Time in pain by animal type, per 100g, in seconds, separated by pain type
 TIME_IN_PAIN_FOR_100G_IN_SECONDS = {
     AnimalType.LAYING_HEN: {
         LayingHenBreedingType.CONVENTIONAL_CAGE: {
-            PainIntensity.EXCRUCIATING: 100,
-            PainIntensity.DISABLING: 2000,
-            PainIntensity.HURTFUL: 3000,
-            PainIntensity.ANNOYING: 4000
+            PainType.PHYSICAL: {
+                PainIntensity.EXCRUCIATING: 70,
+                PainIntensity.DISABLING: 1200,
+                PainIntensity.HURTFUL: 1800,
+                PainIntensity.ANNOYING: 2400
+            },
+            PainType.PSYCHOLOGICAL: {
+                PainIntensity.EXCRUCIATING: 30,
+                PainIntensity.DISABLING: 800,
+                PainIntensity.HURTFUL: 1200,
+                PainIntensity.ANNOYING: 1600
+            }
         },
         LayingHenBreedingType.FURNISHED_CAGE: {
-            PainIntensity.EXCRUCIATING: 100,
-            PainIntensity.DISABLING: 2000,
-            PainIntensity.HURTFUL: 3000,
-            PainIntensity.ANNOYING: 4000
+            PainType.PHYSICAL: {
+                PainIntensity.EXCRUCIATING: 0,
+                PainIntensity.DISABLING: 1100,
+                PainIntensity.HURTFUL: 1700,
+                PainIntensity.ANNOYING: 2300
+            },
+            PainType.PSYCHOLOGICAL: {
+                PainIntensity.EXCRUCIATING: 40,
+                PainIntensity.DISABLING: 900,
+                PainIntensity.HURTFUL: 1300,
+                PainIntensity.ANNOYING: 1700
+            }
         },
         LayingHenBreedingType.BARN: {
-            PainIntensity.EXCRUCIATING: 100,
-            PainIntensity.DISABLING: 2000,
-            PainIntensity.HURTFUL: 3000,
-            PainIntensity.ANNOYING: 4000
+            PainType.PHYSICAL: {
+                PainIntensity.EXCRUCIATING: 50,
+                PainIntensity.DISABLING: 1000,
+                PainIntensity.HURTFUL: 1500,
+                PainIntensity.ANNOYING: 2000
+            },
+            PainType.PSYCHOLOGICAL: {
+                PainIntensity.EXCRUCIATING: 50,
+                PainIntensity.DISABLING: 1000,
+                PainIntensity.HURTFUL: 1500,
+                PainIntensity.ANNOYING: 2000
+            }
         },
         LayingHenBreedingType.FREE_RANGE: {
-            PainIntensity.EXCRUCIATING: 0,
-            PainIntensity.DISABLING: 111,
-            PainIntensity.HURTFUL: 2222,
-            PainIntensity.ANNOYING: 33333
+            PainType.PHYSICAL: {
+                PainIntensity.EXCRUCIATING: 0,
+                PainIntensity.DISABLING: 60,
+                PainIntensity.HURTFUL: 1000,
+                PainIntensity.ANNOYING: 16000
+            },
+            PainType.PSYCHOLOGICAL: {
+                PainIntensity.EXCRUCIATING: 0,
+                PainIntensity.DISABLING: 51,
+                PainIntensity.HURTFUL: 1222,
+                PainIntensity.ANNOYING: 17333
+            }
         },
     },
     AnimalType.BROILER_CHICKEN: {
         BroilerChickenBreedingType.FREE_RANGE: {
-            PainIntensity.EXCRUCIATING: 120,
-            PainIntensity.DISABLING: 4500,
-            PainIntensity.HURTFUL: 8000,
-            PainIntensity.ANNOYING: 35000
+            PainType.PHYSICAL: {
+                PainIntensity.EXCRUCIATING: 70,
+                PainIntensity.DISABLING: 2500,
+                PainIntensity.HURTFUL: 4000,
+                PainIntensity.ANNOYING: 18000
+            },
+            PainType.PSYCHOLOGICAL: {
+                PainIntensity.EXCRUCIATING: 50,
+                PainIntensity.DISABLING: 2000,
+                PainIntensity.HURTFUL: 4000,
+                PainIntensity.ANNOYING: 17000
+            }
         },
     }
     # Here will come data for other animals...

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -17,47 +17,52 @@ class BroilerChickenBreedingType(StrEnum):
     FREE_RANGE = auto()
 
 
-class PainType(StrEnum):
+class PainIntensity(StrEnum):
     EXCRUCIATING = auto()
     DISABLING = auto()
     HURTFUL = auto()
     ANNOYING = auto()
 
 
+class PainType(StrEnum):
+    PHYSICAL = auto()
+    PSYCHOLOGICAL = auto()
+
+
 # Time in pain by animal type, per 100g, in seconds
 TIME_IN_PAIN_FOR_100G_IN_SECONDS = {
     AnimalType.LAYING_HEN: {
         LayingHenBreedingType.CONVENTIONAL_CAGE: {
-            PainType.EXCRUCIATING: 100,
-            PainType.DISABLING: 2000,
-            PainType.HURTFUL: 3000,
-            PainType.ANNOYING: 4000
+            PainIntensity.EXCRUCIATING: 100,
+            PainIntensity.DISABLING: 2000,
+            PainIntensity.HURTFUL: 3000,
+            PainIntensity.ANNOYING: 4000
         },
         LayingHenBreedingType.FURNISHED_CAGE: {
-            PainType.EXCRUCIATING: 100,
-            PainType.DISABLING: 2000,
-            PainType.HURTFUL: 3000,
-            PainType.ANNOYING: 4000
+            PainIntensity.EXCRUCIATING: 100,
+            PainIntensity.DISABLING: 2000,
+            PainIntensity.HURTFUL: 3000,
+            PainIntensity.ANNOYING: 4000
         },
         LayingHenBreedingType.BARN: {
-            PainType.EXCRUCIATING: 100,
-            PainType.DISABLING: 2000,
-            PainType.HURTFUL: 3000,
-            PainType.ANNOYING: 4000
+            PainIntensity.EXCRUCIATING: 100,
+            PainIntensity.DISABLING: 2000,
+            PainIntensity.HURTFUL: 3000,
+            PainIntensity.ANNOYING: 4000
         },
         LayingHenBreedingType.FREE_RANGE: {
-            PainType.EXCRUCIATING: 0,
-            PainType.DISABLING: 111,
-            PainType.HURTFUL: 2222,
-            PainType.ANNOYING: 33333
+            PainIntensity.EXCRUCIATING: 0,
+            PainIntensity.DISABLING: 111,
+            PainIntensity.HURTFUL: 2222,
+            PainIntensity.ANNOYING: 33333
         },
     },
     AnimalType.BROILER_CHICKEN: {
         BroilerChickenBreedingType.FREE_RANGE: {
-            PainType.EXCRUCIATING: 120,
-            PainType.DISABLING: 4500,
-            PainType.HURTFUL: 8000,
-            PainType.ANNOYING: 35000
+            PainIntensity.EXCRUCIATING: 120,
+            PainIntensity.DISABLING: 4500,
+            PainIntensity.HURTFUL: 8000,
+            PainIntensity.ANNOYING: 35000
         },
     }
     # Here will come data for other animals...
@@ -71,5 +76,8 @@ TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE = {
         LayingHenBreedingType.BARN: ["en:barn-chicken-eggs"],
         LayingHenBreedingType.FREE_RANGE: ["en:free-range-chicken-eggs", "en:organic-eggs"],
     },
-    AnimalType.BROILER_CHICKEN: {},
+    AnimalType.BROILER_CHICKEN: {
+        # Can be tested with this barcode: 3256229237063
+        # BroilerChickenBreedingType.FREE_RANGE: ["en:cooked-chicken-breast-slices"]
+    },
 }

--- a/backend/app/schemas/open_food_facts/internal.py
+++ b/backend/app/schemas/open_food_facts/internal.py
@@ -2,29 +2,46 @@ from typing import Dict, List
 
 from pydantic import BaseModel, HttpUrl
 
-from app.enums.open_food_facts.enums import AnimalType, BroilerChickenBreedingType, LayingHenBreedingType, PainIntensity
+from app.enums.open_food_facts.enums import (
+    AnimalType,
+    BroilerChickenBreedingType,
+    LayingHenBreedingType,
+    PainIntensity,
+    PainType,
+)
 
 
 # Pain report models, used for calculation
 class BreedingTypeAndWeight(BaseModel):
-    animal_type: AnimalType
     breeding_type: LayingHenBreedingType | BroilerChickenBreedingType
     animal_product_weight: int = 0  # in grams
 
 
-class AnimalPainDuration(BaseModel):
-    animal_type: AnimalType
+class PainLevelData(BaseModel):
+    pain_intensity: PainIntensity
+    pain_type: PainType
     seconds_in_pain: int
 
 
-class PainCategory(BaseModel):
-    pain_intensity: PainIntensity
-    animals: List[AnimalPainDuration]
+class AnimalPainReport(BaseModel):
+    animal_type: AnimalType
+    pain_levels: List[PainLevelData]
+    breeding_type_with_weight: BreedingTypeAndWeight
+
+    def get_pain_levels_by_type(self, pain_type: PainType) -> List[PainLevelData]:
+        """Returns the PainLevelData objects for a specific pain type, sorted by intensity"""
+        pain_levels_by_type = [
+            pain_level for pain_level in self.pain_levels if pain_level.pain_type is pain_type
+        ]
+
+        # Sort by intensity order using the class method
+        return sorted(
+            pain_levels_by_type, key=lambda pain: PainIntensity.get_intensity_order().index(pain.pain_intensity)
+        )
 
 
 class PainReport(BaseModel):
-    pain_categories: List[PainCategory]
-    breeding_types_with_weights: List[BreedingTypeAndWeight]
+    animals: List[AnimalPainReport]
 
 
 # Knowledge panel response models

--- a/backend/app/schemas/open_food_facts/internal.py
+++ b/backend/app/schemas/open_food_facts/internal.py
@@ -1,10 +1,11 @@
-from typing import List
+from typing import Dict, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl
 
-from app.enums.open_food_facts.enums import AnimalType, BroilerChickenBreedingType, LayingHenBreedingType, PainType
+from app.enums.open_food_facts.enums import AnimalType, BroilerChickenBreedingType, LayingHenBreedingType, PainIntensity
 
 
+# Pain report models, used for calculation
 class BreedingTypeAndWeight(BaseModel):
     animal_type: AnimalType
     breeding_type: LayingHenBreedingType | BroilerChickenBreedingType
@@ -17,7 +18,7 @@ class AnimalPainDuration(BaseModel):
 
 
 class PainCategory(BaseModel):
-    pain_type: PainType
+    pain_intensity: PainIntensity
     animals: List[AnimalPainDuration]
 
 
@@ -26,8 +27,39 @@ class PainReport(BaseModel):
     breeding_types_with_weights: List[BreedingTypeAndWeight]
 
 
+# Knowledge panel response models
+class TextElement(BaseModel):
+    html: str
+
+
+class PanelElement(BaseModel):
+    panel_id: str
+
+
+class Element(BaseModel):
+    element_type: str
+    text_element: TextElement | None  = None
+    panel_element: PanelElement | None = None
+
+
+class TitleElement(BaseModel):
+    grade: str
+    title: str
+    type: str
+    subtitle: str | None = None
+    name: str | None = None
+    icon_url: HttpUrl | None = None
+
+
+class Panel(BaseModel):
+    elements: List[Element]
+    level: str
+    title_element: TitleElement
+    topics: List[str]
+
+
 class KnowledgePanelResponse(BaseModel):
     """
     Response model for knowledge panel endpoint.
     """
-    pain_report: PainReport
+    panels: Dict[str, Panel]

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -28,19 +28,19 @@ async def test_get_off_knowledge_panel(async_client: AsyncClient):
         "pain_categories": [
             {
                 "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 200}],
-                "pain_type": "excruciating",
+                "pain_intensity": "excruciating",
             },
             {
                 "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 4000}],
-                "pain_type": "disabling",
+                "pain_intensity": "disabling",
             },
             {
                 "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 6000}],
-                "pain_type": "hurtful",
+                "pain_intensity": "hurtful",
             },
             {
                 "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 8000}],
-                "pain_type": "annoying",
+                "pain_intensity": "annoying",
             },
         ],
         "breeding_types_with_weights": [

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -15,7 +15,7 @@ async def test_get_off_knowledge_panel(async_client: AsyncClient):
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = AsyncMock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.randint", return_value=200):
+    with patch("app.business.open_food_facts.pain_report_calculator.randint", return_value=200):
         with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
             # Get the instance returned by the async context
             instance = mock_http_client.return_value.__aenter__.return_value
@@ -23,32 +23,19 @@ async def test_get_off_knowledge_panel(async_client: AsyncClient):
             response = await async_client.get("/off/v1/knowledge-panel/1")
 
     assert response.status_code == 200
-    assert response.json() == {
-    "pain_report": {
-        "pain_categories": [
-            {
-                "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 200}],
-                "pain_intensity": "excruciating",
-            },
-            {
-                "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 4000}],
-                "pain_intensity": "disabling",
-            },
-            {
-                "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 6000}],
-                "pain_intensity": "hurtful",
-            },
-            {
-                "animals": [{"animal_type": "laying_hen", "seconds_in_pain": 8000}],
-                "pain_intensity": "annoying",
-            },
-        ],
-        "breeding_types_with_weights": [
-            {
-                "animal_type": "laying_hen",
-                "breeding_type": "furnished_cage",
-                "animal_product_weight": 200,
-            }
-        ]
-    },
-}
+    # Test response has the expected structure
+    response_data = response.json()
+    assert "panels" in response_data
+    assert "main" in response_data["panels"]
+    assert "physical_pain" in response_data["panels"]
+    assert "psychological_pain" in response_data["panels"]
+    assert "intensities_definitions" in response_data["panels"]
+    
+    # Check panels structure
+    for panel in response_data["panels"].values():
+        assert "elements" in panel
+        assert "title_element" in panel
+
+        # Check title element structure
+        title_element = panel["title_element"]
+        assert "title" in title_element

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -3,12 +3,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from app.business.open_food_facts.knowledge_panel import get_data_from_off
+from app.business.open_food_facts.knowledge_panel import (
+    KnowledgePanelGenerator,
+    get_data_from_off,
+    get_knowledge_panel_response,
+)
 from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import ResourceNotFoundException
-from app.enums.open_food_facts.enums import AnimalType, LayingHenBreedingType
+from app.enums.open_food_facts.enums import AnimalType, LayingHenBreedingType, PainIntensity, PainType
 from app.schemas.open_food_facts.external import ProductData
-from app.schemas.open_food_facts.internal import BreedingTypeAndWeight
+from app.schemas.open_food_facts.internal import (
+    BreedingTypeAndWeight,
+    KnowledgePanelResponse,
+)
 
 
 @pytest.mark.asyncio
@@ -21,6 +28,7 @@ async def test_get_data_from_off_success():
 
     mock_response = AsyncMock()
     mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = AsyncMock(return_value=None)
 
     with patch("httpx.AsyncClient.get", return_value=mock_response):
         result = await get_data_from_off(barcode)
@@ -36,6 +44,7 @@ async def test_get_data_from_off_no_hits():
 
     mock_response = AsyncMock()
     mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = AsyncMock(return_value=None)
 
     with patch("httpx.AsyncClient.get", return_value=mock_response):
         with pytest.raises(ResourceNotFoundException, match=f"No hits returned by OFF API: {barcode}"):
@@ -50,6 +59,7 @@ async def test_get_data_from_off_validation_error():
 
     mock_response = AsyncMock()
     mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = AsyncMock(return_value=None)
 
     with patch("httpx.AsyncClient.get", return_value=mock_response):
         with pytest.raises(
@@ -64,35 +74,123 @@ async def test_get_data_from_off_http_call_exception():
     """Test when the OFF API returns an HTTP error"""
     barcode = "111111111"
 
-    with patch("httpx.AsyncClient.get", side_effect=httpx.ReadTimeout("Network error")):
+    with patch("httpx.AsyncClient.__aenter__", side_effect=httpx.ReadTimeout("Network error")):
         with pytest.raises(ResourceNotFoundException, match=f"Can't get product data from OFF API: {barcode}"):
             await get_data_from_off(barcode)
 
 
-@pytest.mark.asyncio
-async def test_compute_weight(product_data: ProductData):
+def test_compute_breeding_types_with_weights():
+    """Test computing breeding types with weights"""
+    product_data = ProductData(categories_tags=["en:cage-chicken-eggs"], labels_tags=["organic"])
     calculator = PainReportCalculator(product_data)
 
     breeding_types = calculator._get_breeding_types()
-    with patch("app.business.open_food_facts.knowledge_panel.randint", return_value=200):
+    with patch("app.business.open_food_facts.pain_report_calculator.randint", return_value=200):
         result = calculator._get_breeding_types_with_weights(breeding_types)
 
     # product_data fixture contains the `en:cage-chicken-eggs` tag
-    assert result == [
-        BreedingTypeAndWeight(
-            animal_type=AnimalType.LAYING_HEN,
-            breeding_type=LayingHenBreedingType.FURNISHED_CAGE,
-            animal_product_weight=200,
-        )
-    ]
+    assert AnimalType.LAYING_HEN in result
+    assert result[AnimalType.LAYING_HEN].breeding_type == LayingHenBreedingType.FURNISHED_CAGE
+    assert result[AnimalType.LAYING_HEN].animal_product_weight == 200
 
 
-@pytest.mark.asyncio
-async def test_compute_breading_type(product_data: ProductData):
-    # product_data fixture contains the `en:cage-chicken-eggs` tag
+def test_get_breeding_types():
+    """Test getting breeding types from product data"""
+    product_data = ProductData(categories_tags=["en:cage-chicken-eggs"], labels_tags=["organic"])
     calculator = PainReportCalculator(product_data)
 
     result = calculator._get_breeding_types()
-    assert result == [
-        BreedingTypeAndWeight(animal_type=AnimalType.LAYING_HEN, breeding_type=LayingHenBreedingType.FURNISHED_CAGE)
-    ]
+    assert AnimalType.LAYING_HEN in result
+    assert result[AnimalType.LAYING_HEN].breeding_type == LayingHenBreedingType.FURNISHED_CAGE
+
+
+def test_generate_pain_levels_for_type():
+    """Test generating pain levels for a specific animal, breeding type, and pain type"""
+    product_data = ProductData(categories_tags=["en:cage-chicken-eggs"], labels_tags=["organic"])
+    calculator = PainReportCalculator(product_data)
+    
+    breeding_type = BreedingTypeAndWeight(
+        breeding_type=LayingHenBreedingType.FURNISHED_CAGE,
+        animal_product_weight=200
+    )
+    
+    # Test generating physical pain levels
+    physical_pain_levels = calculator._generate_pain_levels_for_type(
+        AnimalType.LAYING_HEN, 
+        breeding_type, 
+        PainType.PHYSICAL
+    )
+    
+    assert len(physical_pain_levels) == 4  # One for each intensity
+    for level in physical_pain_levels:
+        assert level.pain_type == PainType.PHYSICAL
+        assert isinstance(level.pain_intensity, PainIntensity)
+        assert isinstance(level.seconds_in_pain, int)
+        
+    # Test generating psychological pain levels
+    psychological_pain_levels = calculator._generate_pain_levels_for_type(
+        AnimalType.LAYING_HEN, 
+        breeding_type, 
+        PainType.PSYCHOLOGICAL
+    )
+    
+    assert len(psychological_pain_levels) == 4  # One for each intensity
+    for level in psychological_pain_levels:
+        assert level.pain_type == PainType.PSYCHOLOGICAL
+        assert isinstance(level.pain_intensity, PainIntensity)
+        assert isinstance(level.seconds_in_pain, int)
+
+
+def test_knowledge_panel_generator(pain_report):
+    """Test the KnowledgePanelGenerator class"""
+    # Create generator and test individual methods
+    generator = KnowledgePanelGenerator(pain_report)
+    
+    # Test main panel
+    main_panel = generator.create_main_panel()
+    assert main_panel.level == "info"
+    assert main_panel.title_element.title == "Empreinte souffrance"
+    assert len(main_panel.elements) > 3
+    
+    # Test intensities definitions panel
+    intensities_panel = generator.create_intensities_definitions_panel()
+    assert intensities_panel.title_element.title == "Définitions des niveaux d'intensité"
+    assert len(intensities_panel.elements) == 4  # One for each intensity
+    
+    # Test physical pain panel
+    physical_panel = generator.create_physical_pain_panel()
+    assert physical_panel.title_element.title == "Douleur physique"
+    assert len(physical_panel.elements) > 3  # Intro, description, animal pain data, and footer
+    
+    # Test psychological pain panel
+    psychological_panel = generator.create_psychological_pain_panel()
+    assert psychological_panel.title_element.title == "Douleur psychologique"
+    assert len(psychological_panel.elements) > 3  # Intro, description, animal pain data, and footer
+    
+    # Test animal pain element generation
+    animal_element = generator.get_animal_pain_for_panel(AnimalType.LAYING_HEN, PainType.PHYSICAL)
+    assert animal_element is not None
+    assert animal_element.element_type == "text"
+    assert "Poule pondeuse" in animal_element.text_element.html
+    
+    # Test complete response
+    response = generator.get_response()
+    assert isinstance(response, KnowledgePanelResponse)
+    assert len(response.panels) == 4
+
+
+def test_get_knowledge_panel_response(pain_report):
+    """Test the get_knowledge_panel_response function"""
+    # Generate knowledge panel response using the function
+    response = get_knowledge_panel_response(pain_report)
+    
+    # Verify response structure
+    assert "main" in response.panels
+    assert "physical_pain" in response.panels
+    assert "psychological_pain" in response.panels
+    assert "intensities_definitions" in response.panels
+    
+    # Verify each panel has the required fields
+    for panel in response.panels.values():
+        assert hasattr(panel, "elements")
+        assert hasattr(panel, "title_element")

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -3,7 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from app.business.open_food_facts.knowledge_panel import PainReportCalculator, get_data_from_off
+from app.business.open_food_facts.knowledge_panel import get_data_from_off
+from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import ResourceNotFoundException
 from app.enums.open_food_facts.enums import AnimalType, LayingHenBreedingType
 from app.schemas.open_food_facts.external import ProductData

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,12 +1,14 @@
-from typing import AsyncGenerator
+from typing import AsyncGenerator, List
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from starlette.testclient import TestClient
 
+from app.enums.open_food_facts.enums import AnimalType, LayingHenBreedingType, PainIntensity, PainType
 from app.main import app
 from app.schemas.open_food_facts.external import ProductData
+from app.schemas.open_food_facts.internal import AnimalPainReport, BreedingTypeAndWeight, PainLevelData, PainReport
 
 
 @pytest_asyncio.fixture
@@ -31,7 +33,68 @@ def client() -> TestClient:
 
 @pytest.fixture
 def product_data() -> ProductData:
+    """
+    Fixture that provides sample product data for testing.
+    Contains cage chicken eggs category.
+    """
     return ProductData(
         categories_tags=["cat1", "en:cage-chicken-eggs"],
         labels_tags=["label1", "label2"]
     )
+
+
+@pytest.fixture
+def laying_hen_breeding_type() -> BreedingTypeAndWeight:
+    """
+    Fixture that provides a sample BreedingTypeAndWeight for laying hens.
+    """
+    return BreedingTypeAndWeight(
+        breeding_type=LayingHenBreedingType.FURNISHED_CAGE,
+        animal_product_weight=200
+    )
+
+
+@pytest.fixture
+def pain_levels() -> List[PainLevelData]:
+    """
+    Fixture that provides a list of PainLevelData objects for all pain types and intensities.
+    """
+    pain_levels = []
+    
+    # Add physical pain levels
+    for intensity in PainIntensity:
+        pain_levels.append(PainLevelData(
+            pain_intensity=intensity,
+            pain_type=PainType.PHYSICAL,
+            seconds_in_pain=100
+        ))
+    
+    # Add psychological pain levels
+    for intensity in PainIntensity:
+        pain_levels.append(PainLevelData(
+            pain_intensity=intensity,
+            pain_type=PainType.PSYCHOLOGICAL,
+            seconds_in_pain=200
+        ))
+        
+    return pain_levels
+
+
+@pytest.fixture
+def animal_pain_report(laying_hen_breeding_type, pain_levels) -> AnimalPainReport:
+    """
+    Fixture that provides a sample AnimalPainReport for a laying hen.
+    """
+    return AnimalPainReport(
+        animal_type=AnimalType.LAYING_HEN,
+        pain_levels=pain_levels,
+        breeding_type_with_weight=laying_hen_breeding_type
+    )
+
+
+@pytest.fixture
+def pain_report(animal_pain_report) -> PainReport:
+    """
+    Fixture that provides a sample PainReport containing one animal.
+    """
+    return PainReport(animals=[animal_pain_report])

--- a/frontend/app/off/knowledge_panel.css
+++ b/frontend/app/off/knowledge_panel.css
@@ -1,18 +1,18 @@
 .panel-content a {
-    color: #f97316; /* Orange-500 de Tailwind */
-    text-decoration: underline;
+  color: #f97316; /* Orange-500 de Tailwind */
+  text-decoration: underline;
 }
 
 .panel-content a:hover {
-    color: #ea580c; /* Orange-600 de Tailwind */
+  color: #ea580c; /* Orange-600 de Tailwind */
 }
 
 .panel-content ul {
-    list-style-type: disc;
-    padding-left: 1.5rem;
-    margin: 0.5rem 0;
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
 }
 
 .panel-content li {
-    margin-bottom: 0.25rem;
+  margin-bottom: 0.25rem;
 }

--- a/frontend/app/off/knowledge_panel.css
+++ b/frontend/app/off/knowledge_panel.css
@@ -1,0 +1,18 @@
+.panel-content a {
+    color: #f97316; /* Orange-500 de Tailwind */
+    text-decoration: underline;
+}
+
+.panel-content a:hover {
+    color: #ea580c; /* Orange-600 de Tailwind */
+}
+
+.panel-content ul {
+    list-style-type: disc;
+    padding-left: 1.5rem;
+    margin: 0.5rem 0;
+}
+
+.panel-content li {
+    margin-bottom: 0.25rem;
+}

--- a/frontend/app/off/page.tsx
+++ b/frontend/app/off/page.tsx
@@ -1,257 +1,282 @@
 "use client";
 
-import { useState, useEffect } from 'react';
-import './knowledge_panel.css'
+import { useState, useEffect } from "react";
+import "./knowledge_panel.css";
 
 type TextElement = {
-    html: string;
+  html: string;
 };
 
 type PanelElement = {
-    panel_id: string;
+  panel_id: string;
 };
 
 type Element = {
-    element_type: "text" | "panel";
-    text_element: TextElement | null;
-    panel_element: PanelElement | null;
+  element_type: "text" | "panel";
+  text_element: TextElement | null;
+  panel_element: PanelElement | null;
 };
 
 type TitleElement = {
-    grade: string;
-    title: string;
-    type: string;
-    subtitle: string | null;
-    name: string | null;
-    icon_url: string | null;
+  grade: string;
+  title: string;
+  type: string;
+  subtitle: string | null;
+  name: string | null;
+  icon_url: string | null;
 };
 
 type Panel = {
-    elements: Element[];
-    level: string;
-    title_element: TitleElement;
-    topics: string[];
+  elements: Element[];
+  level: string;
+  title_element: TitleElement;
+  topics: string[];
 };
 
 type KnowledgePanelData = {
-    panels: {
-        [key: string]: Panel;
-    };
+  panels: {
+    [key: string]: Panel;
+  };
 };
 
 export default function KnowledgePanel() {
-    const [selectedBarcode, setSelectedBarcode] = useState<string>('3450970045360');
-    const [customBarcode, setCustomBarcode] = useState<string>('');
-    const [showCustomInput, setShowCustomInput] = useState<boolean>(false);
-    const [knowledgePanelData, setKnowledgePanelData] = useState<KnowledgePanelData | null>(null);
-    const [expandedPanels, setExpandedPanels] = useState<Record<string, boolean>>({});
-    const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [error, setError] = useState<string | null>(null);
+  const [selectedBarcode, setSelectedBarcode] =
+    useState<string>("3450970045360");
+  const [customBarcode, setCustomBarcode] = useState<string>("3256229237063"); // Poultry chicken barcode
+  const [showCustomInput, setShowCustomInput] = useState<boolean>(false);
+  const [knowledgePanelData, setKnowledgePanelData] =
+    useState<KnowledgePanelData | null>(null);
+  const [expandedPanels, setExpandedPanels] = useState<Record<string, boolean>>(
+    {},
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
 
-    const barcodes = [
-        '3450970045360',
-        '3270190205685',
-        'custom'
-    ];
+  const barcodes = ["3450970045360", "3270190205685", "custom"];
 
-    useEffect(() => {
-        if (selectedBarcode && selectedBarcode !== 'custom') {
-            fetchKnowledgePanelData(selectedBarcode);
-        }
-    }, [selectedBarcode]);
+  useEffect(() => {
+    if (selectedBarcode && selectedBarcode !== "custom") {
+      fetchKnowledgePanelData(selectedBarcode);
+    }
+  }, [selectedBarcode]);
 
-    const handleBarcodeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const value = e.target.value;
-        setSelectedBarcode(value);
+  const handleBarcodeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    setSelectedBarcode(value);
 
-        if (value === 'custom') {
-            setShowCustomInput(true);
-        } else {
-            setShowCustomInput(false);
-            setCustomBarcode('');
-        }
-    };
+    if (value === "custom") {
+      setShowCustomInput(true);
+    } else {
+      setShowCustomInput(false);
+      setCustomBarcode("");
+    }
+  };
 
-    const handleCustomBarcodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setCustomBarcode(e.target.value);
-    };
+  const handleCustomBarcodeChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setCustomBarcode(e.target.value);
+  };
 
-    const handleCustomBarcodeSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-        if (customBarcode.trim()) {
-            fetchKnowledgePanelData(customBarcode.trim());
-        }
-    };
+  const handleCustomBarcodeSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (customBarcode.trim()) {
+      fetchKnowledgePanelData(customBarcode.trim());
+    }
+  };
 
-    const fetchKnowledgePanelData = async (barcode: string) => {
-        setIsLoading(true);
-        setError(null);
+  const fetchKnowledgePanelData = async (barcode: string) => {
+    setIsLoading(true);
+    setError(null);
 
-        try {
-            const response = await fetch(`http://127.0.0.1:8000/off/v1/knowledge-panel/${barcode}`);
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:8000/off/v1/knowledge-panel/${barcode}`,
+      );
 
-            if (response.status === 404) {
-                setError("This product doesn't contains supported animal products");
-                setKnowledgePanelData(null);
-                return;
-            }
-            else if (!response.ok) {
-                throw new Error(`HTTP Error: ${response.status}`);
-            }
+      if (response.status === 404) {
+        setError("This product doesn't contains supported animal products");
+        setKnowledgePanelData(null);
+        return;
+      } else if (!response.ok) {
+        throw new Error(`HTTP Error: ${response.status}`);
+      }
 
-            const data = await response.json();
-            setKnowledgePanelData(data);
+      const data = await response.json();
+      setKnowledgePanelData(data);
 
-            // Init panels as expanded by default
-            const initialExpandedState: Record<string, boolean> = {};
-            Object.keys(data.panels).forEach(panelId => {
-                initialExpandedState[panelId] = true;
-            });
-            setExpandedPanels(initialExpandedState);
+      // Init panels as expanded by default
+      const initialExpandedState: Record<string, boolean> = {};
+      Object.keys(data.panels).forEach((panelId) => {
+        initialExpandedState[panelId] = true;
+      });
+      setExpandedPanels(initialExpandedState);
+    } catch (err) {
+      setError(
+        `Error fetching knowledge panel: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setKnowledgePanelData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-        } catch (err) {
-            setError(`Error fetching knowledge panel: ${err instanceof Error ? err.message : String(err)}`);
-            setKnowledgePanelData(null);
-        } finally {
-            setIsLoading(false);
-        }
-    };
+  const togglePanel = (panelId: string) => {
+    setExpandedPanels((prev) => ({
+      ...prev,
+      [panelId]: !prev[panelId],
+    }));
+  };
 
-    const togglePanel = (panelId: string) => {
-        setExpandedPanels(prev => ({
-            ...prev,
-            [panelId]: !prev[panelId]
-        }));
-    };
+  const renderElement = (
+    element: Element,
+    panelsData: { [key: string]: Panel },
+    isSubPanel: boolean = false,
+  ) => {
+    if (element.element_type === "text" && element.text_element) {
+      return (
+        <div
+          className="my-2 panel-content"
+          dangerouslySetInnerHTML={{ __html: element.text_element.html }}
+        />
+      );
+    } else if (element.element_type === "panel" && element.panel_element) {
+      const subPanelId = element.panel_element.panel_id;
+      const subPanel = panelsData[subPanelId];
 
-    const renderElement = (element: Element, panelsData: { [key: string]: Panel }, isSubPanel: boolean = false) => {
-        if (element.element_type === "text" && element.text_element) {
-            return (
-                <div
-                    className="my-2 panel-content"
-                    dangerouslySetInnerHTML={{ __html: element.text_element.html }}
-                />
-            );
-        } else if (element.element_type === "panel" && element.panel_element) {
-            const subPanelId = element.panel_element.panel_id;
-            const subPanel = panelsData[subPanelId];
-
-            if (subPanel) {
-                // Add margin-top if this is a sub-panel
-                return (
-                    <div className={isSubPanel ? "mt-6" : ""}>
-                        {renderPanel(subPanelId, subPanel, panelsData, true)}
-                    </div>
-                );
-            }
-        }
-
-        return null;
-    };
-
-    const renderPanel = (panelId: string, panel: Panel, panelsData: { [key: string]: Panel }, isSubPanel: boolean = false) => {
-        const { title_element, elements } = panel;
-        const isExpanded = expandedPanels[panelId];
-
+      if (subPanel) {
+        // Add margin-top if this is a sub-panel
         return (
-            <div key={panelId} className={`border rounded-lg mb-4 overflow-hidden shadow-sm ${isSubPanel ? 'mt-4' : ''}`}>
-                <div
-                    className="flex items-center justify-between p-4 bg-orange-100 cursor-pointer"
-                    onClick={() => togglePanel(panelId)}
-                >
-                    <div className="flex items-center space-x-3">
-                        {title_element.icon_url && (
-                            <img
-                                src={title_element.icon_url}
-                                alt={title_element.title}
-                                className="w-6 h-6"
-                            />
-                        )}
-                        <div>
-                            <h3 className="font-semibold text-lg">{title_element.title}</h3>
-                            {title_element.subtitle && (
-                                <p className="text-sm text-gray-600">{title_element.subtitle}</p>
-                            )}
-                        </div>
-                    </div>
-                    {isExpanded ? <span className="text-lg">▲</span> : <span className="text-lg">▼</span>}
-                </div>
-
-                {isExpanded && (
-                    <div className="p-4 bg-white panel-content">
-                        {elements.map((element, index) => (
-                            <div key={index}>
-                                {renderElement(element, panelsData, isSubPanel)}
-                            </div>
-                        ))}
-                    </div>
-                )}
-            </div>
+          <div className={isSubPanel ? "mt-6" : ""}>
+            {renderPanel(subPanelId, subPanel, panelsData, true)}
+          </div>
         );
-    };
+      }
+    }
+
+    return null;
+  };
+
+  const renderPanel = (
+    panelId: string,
+    panel: Panel,
+    panelsData: { [key: string]: Panel },
+    isSubPanel: boolean = false,
+  ) => {
+    const { title_element, elements } = panel;
+    const isExpanded = expandedPanels[panelId];
 
     return (
-        <div className="container mx-auto p-4 max-w-4xl">
-            <h1 className="text-2xl font-bold mb-6">Knowledge Panel</h1>
-
-            <div className="mb-8 p-4 bg-gray-50 rounded-lg">
-                <h2 className="text-lg font-semibold mb-3">Sélectionner un code-barres</h2>
-
-                <select
-                    value={selectedBarcode}
-                    onChange={handleBarcodeChange}
-                    className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-orange-200 mb-3"
-                >
-                    {barcodes.map((barcode) => (
-                        <option key={barcode} value={barcode}>
-                            {barcode === 'custom' ? 'Autre code-barres...' : barcode}
-                        </option>
-                    ))}
-                </select>
-
-                {showCustomInput && (
-                    <form onSubmit={handleCustomBarcodeSubmit} className="mt-3">
-                        <div className="flex gap-2">
-                            <input
-                                type="text"
-                                value={customBarcode}
-                                onChange={handleCustomBarcodeChange}
-                                placeholder="Entrez un code-barres"
-                                className="flex-1 p-2 border rounded focus:outline-none focus:ring-2 focus:ring-orange-200"
-                                pattern="[0-9]+"
-                                title="Veuillez saisir un code-barres numérique"
-                            />
-                            <button
-                                type="submit"
-                                className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded"
-                                disabled={!customBarcode.trim()}
-                            >
-                                Rechercher
-                            </button>
-                        </div>
-                    </form>
-                )}
+      <div
+        key={panelId}
+        className={`border rounded-lg mb-4 overflow-hidden shadow-sm ${isSubPanel ? "mt-4" : ""}`}
+      >
+        <div
+          className="flex items-center justify-between p-4 bg-orange-100 cursor-pointer"
+          onClick={() => togglePanel(panelId)}
+        >
+          <div className="flex items-center space-x-3">
+            {title_element.icon_url && (
+              <img
+                src={title_element.icon_url}
+                alt={title_element.title}
+                className="w-6 h-6"
+              />
+            )}
+            <div>
+              <h3 className="font-semibold text-lg">{title_element.title}</h3>
+              {title_element.subtitle && (
+                <p className="text-sm text-gray-600">
+                  {title_element.subtitle}
+                </p>
+              )}
             </div>
+          </div>
+          {isExpanded ? (
+            <span className="text-lg">▲</span>
+          ) : (
+            <span className="text-lg">▼</span>
+          )}
+        </div>
 
-            {isLoading && (
-                <div className="text-center py-8">
-                    <p className="text-gray-600">Chargement des données...</p>
-                </div>
-            )}
+        {isExpanded && (
+          <div className="p-4 bg-white panel-content">
+            {elements.map((element, index) => (
+              <div key={index}>
+                {renderElement(element, panelsData, isSubPanel)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
 
-            {error && (
-                <div className="bg-red-100 text-red-700 p-4 rounded mb-4">
-                    {error}
-                </div>
-            )}
+  return (
+    <div className="container mx-auto p-4 max-w-4xl">
+      <h1 className="text-2xl font-bold mb-6">Knowledge Panel</h1>
 
-            {knowledgePanelData && !isLoading && (
-                <div className="space-y-4">
-                    {knowledgePanelData.panels.main && (
-                        renderPanel('main', knowledgePanelData.panels.main, knowledgePanelData.panels)
-                    )}
-                </div>
+      <div className="mb-8 p-4 bg-gray-50 rounded-lg">
+        <h2 className="text-lg font-semibold mb-3">
+          Sélectionner un code-barres
+        </h2>
+
+        <select
+          value={selectedBarcode}
+          onChange={handleBarcodeChange}
+          className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-orange-200 mb-3"
+        >
+          {barcodes.map((barcode) => (
+            <option key={barcode} value={barcode}>
+              {barcode === "custom" ? "Autre code-barres..." : barcode}
+            </option>
+          ))}
+        </select>
+
+        {showCustomInput && (
+          <form onSubmit={handleCustomBarcodeSubmit} className="mt-3">
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={customBarcode}
+                onChange={handleCustomBarcodeChange}
+                placeholder="Entrez un code-barres"
+                className="flex-1 p-2 border rounded focus:outline-none focus:ring-2 focus:ring-orange-200"
+                pattern="[0-9]+"
+                title="Veuillez saisir un code-barres numérique"
+              />
+              <button
+                type="submit"
+                className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded"
+                disabled={!customBarcode.trim()}
+              >
+                Rechercher
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="text-center py-8">
+          <p className="text-gray-600">Chargement des données...</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-red-100 text-red-700 p-4 rounded mb-4">{error}</div>
+      )}
+
+      {knowledgePanelData && !isLoading && (
+        <div className="space-y-4">
+          {knowledgePanelData.panels.main &&
+            renderPanel(
+              "main",
+              knowledgePanelData.panels.main,
+              knowledgePanelData.panels,
             )}
         </div>
-    );
+      )}
+    </div>
+  );
 }

--- a/frontend/app/off/page.tsx
+++ b/frontend/app/off/page.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import './knowledge_panel.css'
+
+type TextElement = {
+    html: string;
+};
+
+type PanelElement = {
+    panel_id: string;
+};
+
+type Element = {
+    element_type: "text" | "panel";
+    text_element: TextElement | null;
+    panel_element: PanelElement | null;
+};
+
+type TitleElement = {
+    grade: string;
+    title: string;
+    type: string;
+    subtitle: string | null;
+    name: string | null;
+    icon_url: string | null;
+};
+
+type Panel = {
+    elements: Element[];
+    level: string;
+    title_element: TitleElement;
+    topics: string[];
+};
+
+type KnowledgePanelData = {
+    panels: {
+        [key: string]: Panel;
+    };
+};
+
+export default function KnowledgePanel() {
+    const [selectedBarcode, setSelectedBarcode] = useState<string>('3450970045360');
+    const [customBarcode, setCustomBarcode] = useState<string>('');
+    const [showCustomInput, setShowCustomInput] = useState<boolean>(false);
+    const [knowledgePanelData, setKnowledgePanelData] = useState<KnowledgePanelData | null>(null);
+    const [expandedPanels, setExpandedPanels] = useState<Record<string, boolean>>({});
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const barcodes = [
+        '3450970045360',
+        '3270190205685',
+        'custom'
+    ];
+
+    useEffect(() => {
+        if (selectedBarcode && selectedBarcode !== 'custom') {
+            fetchKnowledgePanelData(selectedBarcode);
+        }
+    }, [selectedBarcode]);
+
+    const handleBarcodeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value;
+        setSelectedBarcode(value);
+
+        if (value === 'custom') {
+            setShowCustomInput(true);
+        } else {
+            setShowCustomInput(false);
+            setCustomBarcode('');
+        }
+    };
+
+    const handleCustomBarcodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setCustomBarcode(e.target.value);
+    };
+
+    const handleCustomBarcodeSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (customBarcode.trim()) {
+            fetchKnowledgePanelData(customBarcode.trim());
+        }
+    };
+
+    const fetchKnowledgePanelData = async (barcode: string) => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const response = await fetch(`http://127.0.0.1:8000/off/v1/knowledge-panel/${barcode}`);
+
+            if (response.status === 404) {
+                setError("This product doesn't contains supported animal products");
+                setKnowledgePanelData(null);
+                return;
+            }
+            else if (!response.ok) {
+                throw new Error(`HTTP Error: ${response.status}`);
+            }
+
+            const data = await response.json();
+            setKnowledgePanelData(data);
+
+            // Init panels as expanded by default
+            const initialExpandedState: Record<string, boolean> = {};
+            Object.keys(data.panels).forEach(panelId => {
+                initialExpandedState[panelId] = true;
+            });
+            setExpandedPanels(initialExpandedState);
+
+        } catch (err) {
+            setError(`Error fetching knowledge panel: ${err instanceof Error ? err.message : String(err)}`);
+            setKnowledgePanelData(null);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const togglePanel = (panelId: string) => {
+        setExpandedPanels(prev => ({
+            ...prev,
+            [panelId]: !prev[panelId]
+        }));
+    };
+
+    const renderElement = (element: Element, panelsData: { [key: string]: Panel }, isSubPanel: boolean = false) => {
+        if (element.element_type === "text" && element.text_element) {
+            return (
+                <div
+                    className="my-2 panel-content"
+                    dangerouslySetInnerHTML={{ __html: element.text_element.html }}
+                />
+            );
+        } else if (element.element_type === "panel" && element.panel_element) {
+            const subPanelId = element.panel_element.panel_id;
+            const subPanel = panelsData[subPanelId];
+
+            if (subPanel) {
+                // Add margin-top if this is a sub-panel
+                return (
+                    <div className={isSubPanel ? "mt-6" : ""}>
+                        {renderPanel(subPanelId, subPanel, panelsData, true)}
+                    </div>
+                );
+            }
+        }
+
+        return null;
+    };
+
+    const renderPanel = (panelId: string, panel: Panel, panelsData: { [key: string]: Panel }, isSubPanel: boolean = false) => {
+        const { title_element, elements } = panel;
+        const isExpanded = expandedPanels[panelId];
+
+        return (
+            <div key={panelId} className={`border rounded-lg mb-4 overflow-hidden shadow-sm ${isSubPanel ? 'mt-4' : ''}`}>
+                <div
+                    className="flex items-center justify-between p-4 bg-orange-100 cursor-pointer"
+                    onClick={() => togglePanel(panelId)}
+                >
+                    <div className="flex items-center space-x-3">
+                        {title_element.icon_url && (
+                            <img
+                                src={title_element.icon_url}
+                                alt={title_element.title}
+                                className="w-6 h-6"
+                            />
+                        )}
+                        <div>
+                            <h3 className="font-semibold text-lg">{title_element.title}</h3>
+                            {title_element.subtitle && (
+                                <p className="text-sm text-gray-600">{title_element.subtitle}</p>
+                            )}
+                        </div>
+                    </div>
+                    {isExpanded ? <span className="text-lg">▲</span> : <span className="text-lg">▼</span>}
+                </div>
+
+                {isExpanded && (
+                    <div className="p-4 bg-white panel-content">
+                        {elements.map((element, index) => (
+                            <div key={index}>
+                                {renderElement(element, panelsData, isSubPanel)}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    return (
+        <div className="container mx-auto p-4 max-w-4xl">
+            <h1 className="text-2xl font-bold mb-6">Knowledge Panel</h1>
+
+            <div className="mb-8 p-4 bg-gray-50 rounded-lg">
+                <h2 className="text-lg font-semibold mb-3">Sélectionner un code-barres</h2>
+
+                <select
+                    value={selectedBarcode}
+                    onChange={handleBarcodeChange}
+                    className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-orange-200 mb-3"
+                >
+                    {barcodes.map((barcode) => (
+                        <option key={barcode} value={barcode}>
+                            {barcode === 'custom' ? 'Autre code-barres...' : barcode}
+                        </option>
+                    ))}
+                </select>
+
+                {showCustomInput && (
+                    <form onSubmit={handleCustomBarcodeSubmit} className="mt-3">
+                        <div className="flex gap-2">
+                            <input
+                                type="text"
+                                value={customBarcode}
+                                onChange={handleCustomBarcodeChange}
+                                placeholder="Entrez un code-barres"
+                                className="flex-1 p-2 border rounded focus:outline-none focus:ring-2 focus:ring-orange-200"
+                                pattern="[0-9]+"
+                                title="Veuillez saisir un code-barres numérique"
+                            />
+                            <button
+                                type="submit"
+                                className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded"
+                                disabled={!customBarcode.trim()}
+                            >
+                                Rechercher
+                            </button>
+                        </div>
+                    </form>
+                )}
+            </div>
+
+            {isLoading && (
+                <div className="text-center py-8">
+                    <p className="text-gray-600">Chargement des données...</p>
+                </div>
+            )}
+
+            {error && (
+                <div className="bg-red-100 text-red-700 p-4 rounded mb-4">
+                    {error}
+                </div>
+            )}
+
+            {knowledgePanelData && !isLoading && (
+                <div className="space-y-4">
+                    {knowledgePanelData.panels.main && (
+                        renderPanel('main', knowledgePanelData.panels.main, knowledgePanelData.panels)
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Description

This PR adds a demo page that simulates how a knowledge panel will be displayed on OFF.

**A lot of refactoring was done in this PR, so it's quite large (sorry about that). I recommend reviewing knowledge_panel.py by checking out the branch and reading the files directly in your IDE.**

## Code changes

- Added the new Knowledge Panel page
- Implemented the management of pain types (physical and psychological)
- Added docstrings
- Added tests
- Updated the model structures to associate pain intensities with animals instead of the other way around
- Created `KnowledgePanelGenerator` in `knowledge_panel.py` to encapsulate some logic

## How to test

In the backend folder, run:

    task run-server

In the frontend folder, run:

    npm run dev

Go to http://localhost:3000/off and play with the page.

### Screenshot

![Screenshot 2025-03-18 at 20 18 40](https://github.com/user-attachments/assets/70d5ba23-432c-4b2c-a907-91c1fcf33e03)
