### PR TITLE
gets breeding type from categories_tags and cage type from countries_…

### DIFF
--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -122,6 +122,7 @@ async def get_data_from_off_search_a_licious(barcode: str, locale: str) -> Produ
         raise ResourceNotFoundException(f"No hits returned by OFF API: {barcode}")
 
     product_data = product_response.hits[0]
+
     return product_data
 
 

--- a/backend/app/business/open_food_facts/pain_report_calculator.py
+++ b/backend/app/business/open_food_facts/pain_report_calculator.py
@@ -151,9 +151,7 @@ class PainReportCalculator:
 
             # Check if only one breeding_type matched
             if len(matched_breeding_types) == 1:
-                breeding_type = LayingHenBreedingType(
-                    matched_breeding_types[0]
-                ).get_more_specific_breeding_from_country(countries_tags)
+                breeding_type = matched_breeding_types[0].get_more_specific_breeding_from_country(countries_tags)
                 breeding_types_by_animal[animal_type] = BreedingTypeAndWeight(breeding_type=breeding_type)
         return breeding_types_by_animal
 

--- a/backend/app/business/open_food_facts/pain_report_calculator.py
+++ b/backend/app/business/open_food_facts/pain_report_calculator.py
@@ -6,6 +6,7 @@ from app.enums.open_food_facts.enums import (
     TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE,
     TIME_IN_PAIN_FOR_100G_IN_SECONDS,
     AnimalType,
+    LayingHenBreedingType,
     PainIntensity,
     PainType,
 )
@@ -137,17 +138,23 @@ class PainReportCalculator:
             A dictionary mapping animal types to BreedingTypeAndWeight objects with detected breeding types
         """
         breeding_types_by_animal = {}
+        countries_tags = self.product_data.countries_tags
         for animal_type, tags_by_breeding_type in TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE.items():
             # Example of what we get from the for loop:
             # animal_type: AnimalType.LAYING_HEN
             # tags_by_breeding_type: LayingHenBreedingType.FURNISHED_CAGE: ["en:cage-chicken-eggs"]
+            matched_breeding_types = [
+                breeding_type
+                for breeding_type, tags in tags_by_breeding_type.items()
+                if self.product_data.categories_tags and any(tag in self.product_data.categories_tags for tag in tags)
+            ]
 
-            for breeding_type, tags in tags_by_breeding_type.items():
-                if self.product_data.categories_tags and any(tag in self.product_data.categories_tags for tag in tags):
-                    # Set the breeding type if any of the tags is present
-                    breeding_types_by_animal[animal_type] = BreedingTypeAndWeight(breeding_type=breeding_type)
-                    break
-
+            # Check if only one breeding_type matched
+            if len(matched_breeding_types) == 1:
+                breeding_type = LayingHenBreedingType(
+                    matched_breeding_types[0]
+                ).get_more_specific_breeding_from_country(countries_tags)
+                breeding_types_by_animal[animal_type] = BreedingTypeAndWeight(breeding_type=breeding_type)
         return breeding_types_by_animal
 
     def _get_breeding_types_with_weights(

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -168,7 +168,7 @@ TIME_IN_PAIN_FOR_100G_IN_SECONDS = {
 
 TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE = {
     AnimalType.LAYING_HEN: {
-        LayingHenBreedingType.FREE_RANGE: ["en:free-range-chicken-eggs"],
+        LayingHenBreedingType.FREE_RANGE: ["en:free-range-chicken-eggs", "en:organic-eggs"],
         LayingHenBreedingType.BARN: ["en:barn-chicken-eggs"],
         LayingHenBreedingType.CAGE: ["en:cage-chicken-eggs"],
     },

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -13,6 +13,7 @@ class AnimalType(StrEnum):
 
 
 class LayingHenBreedingType(StrEnum):
+    CAGE = auto()
     CONVENTIONAL_CAGE = auto()
     FURNISHED_CAGE = auto()
     BARN = auto()
@@ -21,12 +22,23 @@ class LayingHenBreedingType(StrEnum):
     def translated_name(self, _: Callable) -> str:
         """Return the human-readable name for this breeding type"""
         mappings = {
+            "cage": _("Cage"),
             "conventional_cage": _("Conventional cage"),
             "furnished_cage": _("Furnished cage"),
             "barn": _("Barn"),
             "free_range": _("Free range"),
         }
         return mappings.get(self.value, self.value)
+
+    def get_more_specific_breeding_from_country(self, countries: list[str] | None):
+        """Return the type of cage breeding depending on the sales country"""
+        breeding_type = self
+        if breeding_type == LayingHenBreedingType.CAGE:
+            if countries and any(country in COUNTRIES_WHERE_CAGES_ARE_FURNISHED for country in countries):
+                breeding_type = LayingHenBreedingType.FURNISHED_CAGE
+            else:
+                breeding_type = LayingHenBreedingType.CONVENTIONAL_CAGE
+        return breeding_type
 
 
 class BroilerChickenBreedingType(StrEnum):
@@ -36,6 +48,10 @@ class BroilerChickenBreedingType(StrEnum):
         """Return the human-readable name for this breeding type"""
         mappings = {"free_range": _("Free range")}
         return mappings.get(self.value, self.value)
+
+    def get_more_specific_breeding_from_country(self, countries: list[str] | None):
+        """Return the type of cage breeding depending on the sales country"""
+        return self
 
 
 class PainIntensity(StrEnum):
@@ -152,10 +168,9 @@ TIME_IN_PAIN_FOR_100G_IN_SECONDS = {
 
 TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE = {
     AnimalType.LAYING_HEN: {
-        LayingHenBreedingType.CONVENTIONAL_CAGE: [],
-        LayingHenBreedingType.FURNISHED_CAGE: ["en:cage-chicken-eggs"],
+        LayingHenBreedingType.FREE_RANGE: ["en:free-range-chicken-eggs"],
         LayingHenBreedingType.BARN: ["en:barn-chicken-eggs"],
-        LayingHenBreedingType.FREE_RANGE: ["en:free-range-chicken-eggs", "en:organic-eggs"],
+        LayingHenBreedingType.CAGE: ["en:cage-chicken-eggs"],
     },
     AnimalType.BROILER_CHICKEN: {
         # Can be tested with this barcode: 3256229237063
@@ -164,3 +179,39 @@ TAGS_BY_ANIMAL_TYPE_AND_BREEDING_TYPE = {
         # BroilerChickenBreedingType.FREE_RANGE: ["en:cooked-chicken-breast-slices"]
     },
 }
+
+COUNTRIES_WHERE_CAGES_ARE_FURNISHED = [
+    "en:switzerland",  # conventional cages banned since 1992, phasing out of furnished cages
+    "en:luxembourg",  # no more conventional cages since 2007, furnished cages to be phased out by 2025
+    "en:sweden",  # cage systems banned
+    "en:united-kingdom",  # conventional cages banned since 2012, transition to non-cage systems
+    "en:france",  # EU regulations, ban on new conventional cage installations (2022)
+    "en:germany",  # full exit from conventional cages by 2025, transition to furnished or cage-free systems
+    "en:austria",  # total cage ban by 2025
+    "en:netherlands",  # EU regulations
+    "en:new-zealand",  # total cage ban in 2023
+    "en:belgium",  # EU regulations
+    "en:denmark",  # EU regulations
+    "en:finland",  # EU regulations
+    "en:ireland",  # EU regulations
+    "en:italy",  # EU regulations
+    "en:portugal",  # EU regulations
+    "en:spain",  # EU regulations
+    "en:poland",  # EU regulations
+    "en:czech-republic",  # EU regulations
+    "en:slovenia",  # EU regulations
+    "en:croatia",  # EU regulations
+    "en:bulgaria",  # EU regulations
+    "en:hungary",  # EU regulations
+    "en:latvia",  # EU regulations
+    "en:lithuania",  # EU regulations
+    "en:romania",  # EU regulations
+    "en:estonia",  # EU regulations
+    "en:greece",  # EU regulations
+    "en:reunion",  # same as France
+    "en:guadeloupe",  # same as France
+    "en:martinique",  # same as France
+    "en:mayotte",  # same as France
+    "en:french-guiana",  # same as France
+    "en:new-caledonia",  # same as France
+]

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -115,14 +115,13 @@ def test_compute_breeding_types_with_weights(sample_product_data: ProductData):
 
     # product_data fixture contains the `en:cage-chicken-eggs` tag
     assert AnimalType.LAYING_HEN in result
-    assert result[AnimalType.LAYING_HEN].breeding_type == LayingHenBreedingType.FURNISHED_CAGE
+    assert result[AnimalType.LAYING_HEN].breeding_type == LayingHenBreedingType.CONVENTIONAL_CAGE
     assert result[AnimalType.LAYING_HEN].animal_product_weight == 200
 
 
 def test_get_breeding_types(sample_product_data: ProductData):
     """Test getting breeding types from product data"""
     calculator = PainReportCalculator(sample_product_data)
-
     result = calculator._get_breeding_types()
     assert AnimalType.LAYING_HEN in result
     assert result[AnimalType.LAYING_HEN].breeding_type == LayingHenBreedingType.FURNISHED_CAGE

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -106,8 +106,20 @@ async def test_get_data_from_off_http_call_exception(get_data_from_off_function:
             await get_data_from_off_function(barcode, locale="en")
 
 
-def test_compute_breeding_types_with_weights(sample_product_data: ProductData):
+@pytest.mark.parametrize(
+    "countries, expected_breeding_types",
+    [
+        (["en:france"], LayingHenBreedingType.FURNISHED_CAGE),
+        (["en:united-states"], LayingHenBreedingType.CONVENTIONAL_CAGE),
+    ],
+)
+def test_compute_breeding_types_with_weights(
+    sample_product_data: ProductData,
+    countries,
+    expected_breeding_types,
+):
     """Test computing breeding types with weights"""
+    sample_product_data.countries_tags = countries
     calculator = PainReportCalculator(sample_product_data)
 
     breeding_types = calculator._get_breeding_types()
@@ -115,7 +127,7 @@ def test_compute_breeding_types_with_weights(sample_product_data: ProductData):
 
     # product_data fixture contains the `en:cage-chicken-eggs` tag
     assert AnimalType.LAYING_HEN in result
-    assert result[AnimalType.LAYING_HEN].breeding_type == LayingHenBreedingType.CONVENTIONAL_CAGE
+    assert result[AnimalType.LAYING_HEN].breeding_type == expected_breeding_types
     assert result[AnimalType.LAYING_HEN].animal_product_weight == 200
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -47,7 +47,7 @@ def sample_product_data() -> ProductData:
         ingredients_tags=[],
         ingredients=[],
         countries="fr",
-        countries_tags=["en:france", "en:united-states"],
+        countries_tags=["en:france"],
     )
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -47,7 +47,7 @@ def sample_product_data() -> ProductData:
         ingredients_tags=[],
         ingredients=[],
         countries="fr",
-        countries_tags=["en:france"],
+        countries_tags=["en:france", "en:united-states"],
     )
 
 

--- a/frontend/app/[locale]/off/page.tsx
+++ b/frontend/app/[locale]/off/page.tsx
@@ -58,7 +58,24 @@ export default function KnowledgePanel() {
   const locale = useCurrentLocale() as 'fr' | 'en';
   const t = useI18n();
 
-  const barcodes = ['3450970045360', '3270190205685', 'custom'];
+  const barcodes = [
+    '3450970045360', // cage eggs from France
+    '2000000124898', // cage eggs from usa
+    '8003636004529', // no specific category
+    '3560071098278', // both en:free-range-chicken-eggs AND en:cage-chicken-eggs
+    '3270190205685', // free-range chicken eggs from France
+    '0605388714565 ', // no specific category
+    '50326686', // cage chicken eggs from UK
+    '4311501688120', // barn chicken eggs from Germany
+    '4056489292395 ', // free-range eggs from Germany
+    '9413000012057', // free-range eggs from New-Zealand
+    '9414674989591', // cage eggs from New-Zealand
+    '5202930932252', // free-range eggs, no country
+    '9313715907009', // Poultry chicken barcode
+    '5010482558413', // cage, France and UK
+    '3372140000101', // cage, 2 countries
+    'custom',
+  ];
 
   useEffect(() => {
     if (selectedBarcode && selectedBarcode !== 'custom') {


### PR DESCRIPTION
## Description

Determines breeding type only from categories_tags : free-range, barn or cage
Determines cage type from countries_tags : furnished cage if sold in a country where conventional cages ares banned
If no country, returns conventional_cage, if more than one country, picks the stricter one

Method _get_breeding_types from PainReportCalculator now returns breeding_types free-range, barn, furnished_cage or conventional_cage
Returns nothing if zero or more than one category found in categories_tags among "en:free-range-chicken-eggs", "en:barn-chicken-eggs" and "cage-chicken-eggs'


## Code changes

- added "cage" to class LayingHenBreedingType
- added barcodes to test on off/page.tsx
- added a list COUNTRIES_WHERE_CAGES_ARE_FURNISHED to enums
- added a method get_more_specific_breeding_from_country(countries) to class LayingHenBreedingType, to convert breeding_type cage to furnished_cage or conventional_cage
- added countries_tags to class ProductData
