### PR TITLE
Feature/improve coverage weight breeding

### DIFF
--- a/backend/README_FR.md
+++ b/backend/README_FR.md
@@ -1,4 +1,4 @@
-3# Contribuer au projet Empreinte Souffrance
+# Contribuer au projet Empreinte Souffrance
 
 ## Installer pre-commit
 

--- a/backend/README_FR.md
+++ b/backend/README_FR.md
@@ -1,4 +1,4 @@
-# Contribuer au projet Empreinte Souffrance
+3# Contribuer au projet Empreinte Souffrance
 
 ## Installer pre-commit
 

--- a/backend/app/business/open_food_facts/egg_weight_calculator.py
+++ b/backend/app/business/open_food_facts/egg_weight_calculator.py
@@ -4,6 +4,7 @@ from typing import List
 from app.schemas.open_food_facts.external import ProductData
 
 AVERAGE_EGG_WEIGHT = 50
+LARGE_EGG_WEIGHT = 60
 
 
 UNIT_CONVERSIONS = {
@@ -21,10 +22,26 @@ UNIT_CONVERSIONS = {
 }
 
 EGG_WEIGHTS_BY_TAG = {
-    60: {"large-eggs", "gros-oeufs"},
-    55: {"grade-a-eggs", "grade-aa-eggs"},
-    50: {"medium-eggs"},
+    60: {
+        "en:large-eggs",
+        "en:free-range-organic-large-chicken-eggs",
+        "gros-oeufs",
+        "en:free-range-large-eggs",
+        "en:large-free-run-chicken-eggs",
+    },
+    55: {"en:grade-a-eggs", "en:grade-a-eggs"},
+    50: {"en:medium-eggs-pack-of-10", "en:organic-chicken-eggs-medium-size"},
 }
+
+REGEX_NUMBERS_ONLY = r"\s*\d+(\.\d+)?\s*"
+REGEX_NUMERIC_UNIT = r"\s*(\d+(?:\.\d+)?)\s*((?:[a-zA-Zа-яА-ЯёЁ\u00C0-\u00FFœŒ]+\s*)+)\.?"
+REGEX_X_NUM = r"[xX]\s*(\d+(?:\.\d+)?)"
+REGEX_ADDITION = r"(\d+)\s*\+\s*(\d+)"
+REGEX_EXTRACT_DIGITS = r"\b(\d{1,3})\b"
+
+DOZEN_EXPRESSIONS = ["dozen", "dozens", "dzn", "doz"]
+MOYEN_EXPRESSIONS = ["m", "moyen", "M", "Moyens", "moyens"]
+LARGE_EXPRESSIONS = ["gros", "l", "xl", "large", "Large", "L", "XL", "Gros"]
 
 
 def get_egg_weight_by_tag(categories_tags: List[str]) -> int:
@@ -55,10 +72,76 @@ def get_total_egg_weight_from_tags(categories_tags: List[str]) -> float:
     """
     num_eggs = get_number_of_eggs(categories_tags)
     weight_per_egg = get_egg_weight_by_tag(categories_tags)
+    if num_eggs > 0 and weight_per_egg == 0:
+        return num_eggs * AVERAGE_EGG_WEIGHT
     return weight_per_egg * num_eggs
 
 
-def get_egg_weight_from_quantity(quantity: float, unit: str) -> float:
+def get_egg_weight_from_quantity(quantity: str) -> float:
+    """
+    Parses quantity into weight in grams.
+    """
+    # Case 1: Only numeric (≤30 eggs)
+    parsed = False
+    if re.fullmatch(REGEX_NUMBERS_ONLY, quantity):
+        num = float(quantity)
+        if num <= 30:
+            parsed = True
+            return num * AVERAGE_EGG_WEIGHT
+
+    # Case 2: Numeric + unit (Latin, Cyrillic, accented, etc.)
+    if not parsed:
+        match = re.match(REGEX_NUMERIC_UNIT, quantity)
+        if match:
+            number = float(match.group(1))
+            unit = match.group(2).lower().split()
+            # e.g. '1 dozen'
+            if any([u in DOZEN_EXPRESSIONS for u in unit]):
+                egg_weight = number * 12 * AVERAGE_EGG_WEIGHT
+            # e.g. '12 M'
+            elif any([u in MOYEN_EXPRESSIONS for u in unit]):
+                egg_weight = number * AVERAGE_EGG_WEIGHT
+            # e.g. '12 large'
+            elif any([u in LARGE_EXPRESSIONS for u in unit]):
+                egg_weight = number * LARGE_EGG_WEIGHT
+            else:
+                # e.g. '12 unities'
+                egg_weight = number * AVERAGE_EGG_WEIGHT
+            parsed = True
+            return egg_weight
+
+    # Case 3: x10 / X10 style
+    if not parsed:
+        match = re.match(REGEX_X_NUM, quantity)
+        if match:
+            egg_number = float(match.group(1))
+            parsed = True
+            return egg_number * AVERAGE_EGG_WEIGHT
+
+    # Case 4: Addition expressions: "10 + 2", "12 + 3 oeufs"
+    if not parsed:
+        match = re.search(REGEX_ADDITION, quantity)
+        if match:
+            egg_number = int(match.group(1)) + int(match.group(2))
+            parsed = True
+            return egg_number * AVERAGE_EGG_WEIGHT
+
+    # Case 5: Single number (e.g. "Boîte de 6")
+    if not parsed:
+        match = re.search(REGEX_EXTRACT_DIGITS, quantity)
+        if match:
+            num = int(match.group(1))
+            if num < 1000:
+                parsed = True
+                return num * AVERAGE_EGG_WEIGHT
+
+    if not parsed:
+        return 0
+
+    return 0
+
+
+def get_egg_weight_from_product_quantity_and_unit(quantity: float, unit: str) -> float:
     """
     Converts product quantity and unit into weight in grams.
     """
@@ -79,12 +162,15 @@ def calculate_egg_weight(product_data: ProductData) -> float:
     Returns:
         The egg weight if applicable.
     """
-    quantity = product_data.product_quantity
+    product_quantity = product_data.product_quantity
     unit = product_data.product_quantity_unit
+    quantity = product_data.quantity
     categories_tags = product_data.categories_tags or []
 
-    if quantity and unit:
-        egg_weight = get_egg_weight_from_quantity(quantity, unit)
+    if product_quantity and unit:
+        egg_weight = get_egg_weight_from_product_quantity_and_unit(product_quantity, unit)
+    elif quantity:
+        egg_weight = get_egg_weight_from_quantity(quantity)
     else:
         egg_weight = get_total_egg_weight_from_tags(categories_tags)
 

--- a/backend/app/business/open_food_facts/egg_weight_calculator.py
+++ b/backend/app/business/open_food_facts/egg_weight_calculator.py
@@ -33,15 +33,20 @@ EGG_WEIGHTS_BY_TAG = {
     50: {"en:medium-eggs-pack-of-10", "en:organic-chicken-eggs-medium-size"},
 }
 
+# "6"
 REGEX_NUMBERS_ONLY = r"\s*\d+(\.\d+)?\s*"
+# "6 eggs"
 REGEX_NUMERIC_UNIT = r"\s*(\d+(?:\.\d+)?)\s*((?:[a-zA-Zа-яА-ЯёЁ\u00C0-\u00FFœŒ]+\s*)+)\.?"
+# "x10"
 REGEX_X_NUM = r"[xX]\s*(\d+(?:\.\d+)?)"
+# "10+2 eggs"
 REGEX_ADDITION = r"(\d+)\s*\+\s*(\d+)"
+# "a big box of 10 eggs"
 REGEX_EXTRACT_DIGITS = r"\b(\d{1,3})\b"
 
 DOZEN_EXPRESSIONS = ["dozen", "dozens", "dzn", "doz"]
-MOYEN_EXPRESSIONS = ["m", "moyen", "M", "Moyens", "moyens"]
-LARGE_EXPRESSIONS = ["gros", "l", "xl", "large", "Large", "L", "XL", "Gros"]
+MOYEN_EXPRESSIONS = ["m", "moyen", "moyens"]
+LARGE_EXPRESSIONS = ["gros", "l", "xl", "large"]
 
 
 def get_egg_weight_by_tag(categories_tags: List[str]) -> int:
@@ -72,15 +77,21 @@ def get_total_egg_weight_from_tags(categories_tags: List[str]) -> float:
     """
     num_eggs = get_number_of_eggs(categories_tags)
     weight_per_egg = get_egg_weight_by_tag(categories_tags)
-    if num_eggs > 0 and weight_per_egg == 0:
-        return num_eggs * AVERAGE_EGG_WEIGHT
-    return weight_per_egg * num_eggs
+
+    if num_eggs == 0:
+        return 0
+    if weight_per_egg > 0:
+        return num_eggs * weight_per_egg
+    return num_eggs * AVERAGE_EGG_WEIGHT
 
 
 def get_egg_weight_from_quantity(quantity: str) -> float:
     """
     Parses quantity into weight in grams.
     """
+    if not quantity:
+        return 0
+
     # Case 1: Only numeric (≤30 eggs)
     parsed = False
     if re.fullmatch(REGEX_NUMBERS_ONLY, quantity):
@@ -96,13 +107,13 @@ def get_egg_weight_from_quantity(quantity: str) -> float:
             number = float(match.group(1))
             unit = match.group(2).lower().split()
             # e.g. '1 dozen'
-            if any([u in DOZEN_EXPRESSIONS for u in unit]):
+            if any([u.lower() in DOZEN_EXPRESSIONS for u in unit]):
                 egg_weight = number * 12 * AVERAGE_EGG_WEIGHT
             # e.g. '12 M'
-            elif any([u in MOYEN_EXPRESSIONS for u in unit]):
+            elif any([u.lower() in MOYEN_EXPRESSIONS for u in unit]):
                 egg_weight = number * AVERAGE_EGG_WEIGHT
             # e.g. '12 large'
-            elif any([u in LARGE_EXPRESSIONS for u in unit]):
+            elif any([u.lower() in LARGE_EXPRESSIONS for u in unit]):
                 egg_weight = number * LARGE_EGG_WEIGHT
             else:
                 # e.g. '12 unities'
@@ -136,6 +147,7 @@ def get_egg_weight_from_quantity(quantity: str) -> float:
                 return num * AVERAGE_EGG_WEIGHT
 
     if not parsed:
+        print(f"Could not parse quantity: {quantity}")
         return 0
 
     return 0

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -90,6 +90,7 @@ async def get_data_from_off_search_a_licious(barcode: str, locale: str) -> Produ
         product_name_with_locale,
         "product_quantity_unit",
         "product_quantity",
+        "quantity",
         "allergens_tags",
         "ingredients_tags",
         "ingredients",

--- a/backend/app/schemas/open_food_facts/external.py
+++ b/backend/app/schemas/open_food_facts/external.py
@@ -12,6 +12,7 @@ class ProductData(BaseModel):
     labels_tags: List[str] | None = None
     image_url: HttpUrl | None = None
     product_name: str
+    quantity: str | None = None
     product_quantity_unit: str | None = None
     product_quantity: float | None = None
     allergens_tags: List[str] | None = None

--- a/backend/app/schemas/open_food_facts/external.py
+++ b/backend/app/schemas/open_food_facts/external.py
@@ -11,7 +11,7 @@ class ProductData(BaseModel):
     categories_tags: List[str] | None = None
     labels_tags: List[str] | None = None
     image_url: HttpUrl | None = None
-    product_name: str | None = None
+    product_name: str
     quantity: str | None = None
     product_quantity_unit: str | None = None
     product_quantity: float | None = None

--- a/backend/app/schemas/open_food_facts/external.py
+++ b/backend/app/schemas/open_food_facts/external.py
@@ -11,7 +11,7 @@ class ProductData(BaseModel):
     categories_tags: List[str] | None = None
     labels_tags: List[str] | None = None
     image_url: HttpUrl | None = None
-    product_name: str
+    product_name: str | None = None
     quantity: str | None = None
     product_quantity_unit: str | None = None
     product_quantity: float | None = None

--- a/backend/app/scripts/retrieve_laying_hens_fr_data.py
+++ b/backend/app/scripts/retrieve_laying_hens_fr_data.py
@@ -34,7 +34,7 @@ def fetch_all_pages() -> List[Dict]:
     print("Fetching API data...")
     while True:
         print(f"  Processing page {current_page}...")
-        response = requests.get(API_URL, params=params, headers=headers)
+        response = requests.get(API_URL, params=params, headers=headers)  # type: ignore
 
         if response.status_code != 200:
             print(f"Error: API request failed with status {response.status_code}")
@@ -46,7 +46,7 @@ def fetch_all_pages() -> List[Dict]:
         if not page_data.get("next"):
             break
 
-        params["page"] += 1
+        params["page"] += 1  # type: ignore
         current_page += 1
 
     print(f"\nTotal records fetched: {len(data)}")
@@ -159,10 +159,10 @@ def export_to_csv(data: List[Dict]) -> None:
         return
 
     # Collect all field names from the data
-    fieldnames = set()
+    fieldnames = set()  # type: ignore
     for entry in data:
         fieldnames.update(entry.keys())
-    fieldnames = list(fieldnames) + ["volailles_count"]
+    fieldnames = list(fieldnames) + ["volailles_count"]  # type: ignore
 
     # Special handling for nested fields
     nested_fields = ["rubriques", "inspections", "documentsHorsInspection"]

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -11,6 +11,8 @@ from app.business.open_food_facts.breeding_type_calculator import (
     get_cage_regex,
     get_free_range_regex,
 )
+from app.business.open_food_facts.egg_weight_calculator import calculate_egg_weight, AVERAGE_EGG_WEIGHT, \
+    LARGE_EGG_WEIGHT
 from app.business.open_food_facts.knowledge_panel import (
     KnowledgePanelGenerator,
     get_data_from_off_search_a_licious,
@@ -269,3 +271,25 @@ def test_barn_regex(tag, should_match):
 def test_cage_regex(tag, should_match):
     pattern = get_cage_regex()
     assert bool(re.search(pattern, BreedingTypeCalculator._clean(tag))) == should_match
+
+
+# Test weight calculator
+@pytest.mark.parametrize(
+    "product_fixture, expected_weight",
+    [
+        ("number_only_product", 6 * AVERAGE_EGG_WEIGHT),
+        ("numeric_unit_dozen", 12 * AVERAGE_EGG_WEIGHT),
+        ("numeric_unit_moyen", 12 * AVERAGE_EGG_WEIGHT),
+        ("numeric_unit_large", 12 * LARGE_EGG_WEIGHT),
+        ("x_style_product", 10 * AVERAGE_EGG_WEIGHT),
+        ("addition_expression_product", 12 * AVERAGE_EGG_WEIGHT),
+        ("extract_digits_product", 6 * AVERAGE_EGG_WEIGHT),
+        ("tagged_large_egg_product", 6 * LARGE_EGG_WEIGHT),
+        ("product_quantity_with_unit", pytest.approx(0.5 * 453.59, 0.1)),
+        ("unknown_quantity_product", 0),
+        ("no_data_product", 0),
+    ],
+)
+def test_calculate_egg_weight(product_fixture, expected_weight, request):
+    product = request.getfixturevalue(product_fixture)
+    assert calculate_egg_weight(product) == expected_weight

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -11,8 +11,11 @@ from app.business.open_food_facts.breeding_type_calculator import (
     get_cage_regex,
     get_free_range_regex,
 )
-from app.business.open_food_facts.egg_weight_calculator import calculate_egg_weight, AVERAGE_EGG_WEIGHT, \
-    LARGE_EGG_WEIGHT
+from app.business.open_food_facts.egg_weight_calculator import (
+    AVERAGE_EGG_WEIGHT,
+    LARGE_EGG_WEIGHT,
+    calculate_egg_weight,
+)
 from app.business.open_food_facts.knowledge_panel import (
     KnowledgePanelGenerator,
     get_data_from_off_search_a_licious,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -53,50 +53,6 @@ def sample_product_data() -> ProductData:
 
 
 @pytest.fixture
-def weight_product_quantity_and_unit() -> ProductData:
-    """
-    Fixture that provides sample product data for testing.
-    Contains data from product with code 9338295000049
-    """
-    return ProductData(
-        categories_tags=["en:farming-productsen:eggsen:chicken-eggs", "en:free-range-chicken-eggs"],
-        labels_tags=[],
-        product_name="Eggs",
-        image_url=HttpUrl("https://example.com/image.jpg"),
-        quantity="800 g",
-        product_quantity=800,
-        product_quantity_unit="g",
-        allergens_tags=[],
-        ingredients_tags=[],
-        ingredients=[],
-        countries="au",
-        countries_tags=["en:australia"],
-    )
-
-
-@pytest.fixture
-def weight_quantity_only_digits() -> ProductData:
-    """
-    Fixture that provides sample product data for testing.
-    Contains data from product with code 3770007836007
-    """
-    return ProductData(
-        categories_tags=["en:farming-productsen:eggsen:chicken-eggs", "en:free-range-chicken-eggs"],
-        labels_tags=[],
-        product_name="6 oeufs frais plein air de poules Marans",
-        image_url=HttpUrl("https://example.com/image.jpg"),
-        quantity="6",
-        product_quantity=None,
-        product_quantity_unit=None,
-        allergens_tags=[],
-        ingredients_tags=[],
-        ingredients=[],
-        countries="fr",
-        countries_tags=["en:france"],
-    )
-
-
-@pytest.fixture
 def laying_hen_breeding_type() -> BreedingTypeAndWeight:
     """
     Fixture that provides a sample BreedingTypeAndWeight for laying hens.
@@ -144,3 +100,59 @@ def pain_report(animal_pain_report) -> PainReport:
         product_name="Fake product name",
         product_image_url=HttpUrl("https://example.com/image.jpg"),
     )
+
+
+# Weight testing fixtures
+@pytest.fixture
+def number_only_product():
+    return ProductData(quantity="6")
+
+
+@pytest.fixture
+def numeric_unit_dozen():
+    return ProductData(quantity="1 dozen")
+
+
+@pytest.fixture
+def numeric_unit_moyen():
+    return ProductData(quantity="12 moyens")
+
+
+@pytest.fixture
+def numeric_unit_large():
+    return ProductData(quantity="12 large")
+
+
+@pytest.fixture
+def x_style_product():
+    return ProductData(quantity="x10")
+
+
+@pytest.fixture
+def addition_expression_product():
+    return ProductData(quantity="10 + 2")
+
+
+@pytest.fixture
+def extract_digits_product():
+    return ProductData(quantity="Boîte de 6")
+
+
+@pytest.fixture
+def tagged_large_egg_product():
+    return ProductData(categories_tags=["en:large-eggs", "pack-of-6"])
+
+
+@pytest.fixture
+def product_quantity_with_unit():
+    return ProductData(product_quantity=0.5, product_quantity_unit="lbs")
+
+
+@pytest.fixture
+def unknown_quantity_product():
+    return ProductData(quantity="some weird string")
+
+
+@pytest.fixture
+def no_data_product():
+    return ProductData()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -105,54 +105,56 @@ def pain_report(animal_pain_report) -> PainReport:
 # Weight testing fixtures
 @pytest.fixture
 def number_only_product():
-    return ProductData(quantity="6")
+    return ProductData(product_name="Fake product name", quantity="6")
 
 
 @pytest.fixture
 def numeric_unit_dozen():
-    return ProductData(quantity="1 dozen")
+    return ProductData(product_name="Fake product name", quantity="1 dozen")
 
 
 @pytest.fixture
 def numeric_unit_moyen():
-    return ProductData(quantity="12 moyens")
+    return ProductData(product_name="Fake product name", quantity="12 moyens")
 
 
 @pytest.fixture
 def numeric_unit_large():
-    return ProductData(quantity="12 large")
+    return ProductData(product_name="Fake product name", quantity="12 large")
 
 
 @pytest.fixture
 def x_style_product():
-    return ProductData(quantity="x10")
+    return ProductData(product_name="Fake product name", quantity="x10")
 
 
 @pytest.fixture
 def addition_expression_product():
-    return ProductData(quantity="10 + 2")
+    return ProductData(product_name="Fake product name", quantity="10 + 2")
 
 
 @pytest.fixture
 def extract_digits_product():
-    return ProductData(quantity="Boîte de 6")
+    return ProductData(product_name="Fake product name", quantity="Boîte de 6")
 
 
 @pytest.fixture
 def tagged_large_egg_product():
-    return ProductData(categories_tags=["en:large-eggs", "pack-of-6"])
+    return ProductData(product_name="Fake product name", categories_tags=["en:large-eggs", "pack-of-6"])
 
 
 @pytest.fixture
 def product_quantity_with_unit():
-    return ProductData(product_quantity=0.5, product_quantity_unit="lbs")
+    return ProductData(product_name="Fake product name", product_quantity=0.5, product_quantity_unit="lbs")
 
 
 @pytest.fixture
 def unknown_quantity_product():
-    return ProductData(quantity="some weird string")
+    return ProductData(product_name="Fake product name", quantity="some weird string")
 
 
 @pytest.fixture
 def no_data_product():
-    return ProductData()
+    return ProductData(
+        product_name="Fake product name",
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -41,8 +41,53 @@ def sample_product_data() -> ProductData:
         labels_tags=["label1", "label2"],
         product_name="Fake product name",
         image_url=HttpUrl("https://example.com/image.jpg"),
+        quantity="200",
         product_quantity=200,
         product_quantity_unit="g",
+        allergens_tags=[],
+        ingredients_tags=[],
+        ingredients=[],
+        countries="fr",
+        countries_tags=["en:france"],
+    )
+
+
+@pytest.fixture
+def weight_product_quantity_and_unit() -> ProductData:
+    """
+    Fixture that provides sample product data for testing.
+    Contains data from product with code 9338295000049
+    """
+    return ProductData(
+        categories_tags=["en:farming-productsen:eggsen:chicken-eggs", "en:free-range-chicken-eggs"],
+        labels_tags=[],
+        product_name="Eggs",
+        image_url=HttpUrl("https://example.com/image.jpg"),
+        quantity="800 g",
+        product_quantity=800,
+        product_quantity_unit="g",
+        allergens_tags=[],
+        ingredients_tags=[],
+        ingredients=[],
+        countries="au",
+        countries_tags=["en:australia"],
+    )
+
+
+@pytest.fixture
+def weight_quantity_only_digits() -> ProductData:
+    """
+    Fixture that provides sample product data for testing.
+    Contains data from product with code 3770007836007
+    """
+    return ProductData(
+        categories_tags=["en:farming-productsen:eggsen:chicken-eggs", "en:free-range-chicken-eggs"],
+        labels_tags=[],
+        product_name="6 oeufs frais plein air de poules Marans",
+        image_url=HttpUrl("https://example.com/image.jpg"),
+        quantity="6",
+        product_quantity=None,
+        product_quantity_unit=None,
         allergens_tags=[],
         ingredients_tags=[],
         ingredients=[],


### PR DESCRIPTION
## Description

This PR adds "quantity" as another field from OFF API to the ProductData model. It uses it to calculate weight when product quantity and product quantity unit fields are not available. 

## Code changes

<!-- Describe the code changes -->

## How to test

I started writing fixtures in conftest, but did not use them anywhere yet. 
Normally the updated script works for a variety of quantity expressions. When running the server, the following codes can be utilized: 

- Product with both product_quantity_unit and quantity_unit 9338295000049
- Product with no data on weight whatsoever 3537150263100
- Foreign metric (10 бр.) 3800228932032
- Quantity expression of type xNUMBER ('x10') 3222475130328
- Quantity expression of type number + word ('6 eggs') 5000326011228
- Quantity expression with dozen (15 doz.) 2000000124898
- Quantity expression of type num+num (10+2) 3700864012122
- Quantity expressed as number of eggs and egg size (gros oeufs) 3276570206136
