### PR TITLE
added ink in WFI-article-section.tsx && click on the arrow && an attr…

### DIFF
--- a/frontend/app/[locale]/ui/general/home-page/WFI-article-section.tsx
+++ b/frontend/app/[locale]/ui/general/home-page/WFI-article-section.tsx
@@ -5,7 +5,10 @@ export default async function WFIArticleSection() {
   const scopedT = await getScopedI18n('WFIArticle');
 
   return (
-    <section className=" min-h-screen p-8 sm:px-16 w-full bg-[#E7E4FF] flex flex-col gap-5">
+    <section
+      id="WFIArticleSection"
+      className="scroll-mt-18 min-h-screen p-8 sm:px-16 w-full bg-[#E7E4FF] flex flex-col gap-5"
+    >
       <h1 className="w-full text-3xl lg:text-5xl font-bold text-[#3b0a0a] text-left">
         {scopedT('title.part1')}
         <span className="text-[#ff7f7f]">&nbsp;{scopedT('title.strong1')}</span>

--- a/frontend/app/[locale]/ui/general/home-page/hero-section.tsx
+++ b/frontend/app/[locale]/ui/general/home-page/hero-section.tsx
@@ -36,7 +36,13 @@ export default async function HeroSection() {
           <span className="text-4xl">{t('HeroSection.title_sentence.part2')}</span>
           <span className="text-4xl font-bold">{t('HeroSection.title_sentence.strong3')}</span>
         </p>
-        <img src="/arrow_down.png" alt="Flèche vers le bas" className="mt-10 w-10 h-10 animate-bounce" />
+        <a href="#WFIArticleSection" className="scroll-smooth">
+          <img
+            src="/arrow_down.png"
+            alt="Flèche vers le bas"
+            className="mt-10 w-10 h-10 animate-bounce cursor-pointer"
+          />
+        </a>
       </hgroup>
     </header>
   );

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,1 +1,5 @@
 @import 'tailwindcss';
+
+html {
+  scroll-behavior: smooth;
+}


### PR DESCRIPTION
## Description
Smooth scroll effect between the hero section and the first article

## Code changes
- added the html property `{scroll-behavior: smooth}` in the global css for a smooth effect when scrolling html ink
- added `id` in WFI-article-section.tsx for html ink
- added link to redirect to the HTML ink of the first article

## How to test
`npm run dev`

## 
![smoothScroll](https://github.com/user-attachments/assets/6c8093b3-1e45-4076-8daa-118943b47843)
