### PR TITLE
feat: add generic section layout for the Methodology page and its components

### DIFF
--- a/frontend/app/[locale]/calculator/calculator-hero-section.tsx
+++ b/frontend/app/[locale]/calculator/calculator-hero-section.tsx
@@ -1,0 +1,5 @@
+import GenericSection from '../generique-component';
+
+export default function CalculatorHeroSection() {
+  return <GenericSection title={'Calculator Hero Section'} page={'Calculator'} />;
+}

--- a/frontend/app/[locale]/calculator/call-to-action-section.tsx
+++ b/frontend/app/[locale]/calculator/call-to-action-section.tsx
@@ -1,0 +1,5 @@
+import GenericSection from '../generique-component';
+
+export default function CallToActionSection() {
+  return <GenericSection title={'Call To Action Section'} page={'Calculator'} />;
+}

--- a/frontend/app/[locale]/calculator/method-details-section.tsx
+++ b/frontend/app/[locale]/calculator/method-details-section.tsx
@@ -1,0 +1,5 @@
+import GenericSection from '../generique-component';
+
+export default function MethodDetailsSection() {
+  return <GenericSection title={'Method Details Section'} page={'Calculator'} />;
+}

--- a/frontend/app/[locale]/calculator/page.tsx
+++ b/frontend/app/[locale]/calculator/page.tsx
@@ -1,7 +1,13 @@
+import CalculatorHeroSection from './calculator-hero-section';
+import MethodDetailsSection from './method-details-section';
+import CallToActionSection from './call-to-action-section';
+
 export default async function Calculator() {
   return (
     <>
-      <div>Calculator PAGE</div>
+      <CalculatorHeroSection />
+      <MethodDetailsSection />
+      <CallToActionSection />
     </>
   );
 }

--- a/frontend/app/[locale]/generique-component.tsx
+++ b/frontend/app/[locale]/generique-component.tsx
@@ -5,9 +5,10 @@ import React from 'react';
 
 type GenericSectionProps = {
   title: string;
+  page: string;
 };
 
-export default function GenericSection({ title }: GenericSectionProps) {
+export default function GenericSection({ title, page }: GenericSectionProps) {
   return (
     <section className="w-full p-20 px-4 border-b border-gray-200 bg-gradient-to-br from-blue-900 via-blue-600 to-blue-400">
       <div className="max-w-5xl mx-auto p-24">
@@ -20,7 +21,7 @@ export default function GenericSection({ title }: GenericSectionProps) {
           </div>
           <div className="w-full md:w-2/3 text-gray-800">
             <p>
-              Ceci est un bloc pour le composant <strong>{title}</strong> de la page <strong>Méthodologie</strong>.
+              Ceci est un bloc pour le composant <strong>{title}</strong> de la page <strong>{page}</strong>.
               <br />
               <br />
               Le code de ce composant est à remplacer par celui de la maquette.

--- a/frontend/app/[locale]/methodology/generique-component.tsx
+++ b/frontend/app/[locale]/methodology/generique-component.tsx
@@ -1,0 +1,33 @@
+// Composant générique temporaire utilisé pour représenter visuellement une section de la page Méthodologie, en attendant le contenu final.
+// Temporary generic component used to visually represent a section of the Methodology page while waiting for the final content.
+
+import React from 'react';
+
+type GenericSectionProps = {
+  title: string;
+};
+
+export default function GenericSection({ title }: GenericSectionProps) {
+  return (
+    <section className="w-full p-20 px-4 border-b border-gray-200 bg-gradient-to-br from-blue-900 via-blue-600 to-blue-400">
+      <div className="max-w-5xl mx-auto p-24">
+        <h2 className="text-2xl font-bold text-white mb-6">{title}</h2>
+        <div className="flex flex-col md:flex-row items-center gap-6 p-24 rounded-xl shadow-lg border border-white/20 backdrop-blur-md bg-white/30">
+          <div className="w-full md:w-1/3 flex justify-center">
+            <div className="w-48 h-48 rounded overflow-hidden shadow-md">
+              <img src="/suffering_reduction.PNG" alt={title} className="w-full h-full object-cover" />
+            </div>
+          </div>
+          <div className="w-full md:w-2/3 text-gray-800">
+            <p>
+              Ceci est un bloc pour le composant <strong>{title}</strong> de la page <strong>Méthodologie</strong>.
+              <br />
+              <br />
+              Le code de ce composant est à remplacer par celui de la maquette.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/[locale]/methodology/hero-section.tsx
+++ b/frontend/app/[locale]/methodology/hero-section.tsx
@@ -1,0 +1,5 @@
+import GenericSection from './generique-component';
+
+export default function HeroSection() {
+  return <GenericSection title={'Hero Section'} />;
+}

--- a/frontend/app/[locale]/methodology/hero-section.tsx
+++ b/frontend/app/[locale]/methodology/hero-section.tsx
@@ -1,5 +1,5 @@
-import GenericSection from './generique-component';
+import GenericSection from '../generique-component';
 
 export default function HeroSection() {
-  return <GenericSection title={'Hero Section'} />;
+  return <GenericSection title={'Hero Section'} page={'Methodology'} />;
 }

--- a/frontend/app/[locale]/methodology/introduction-section.tsx
+++ b/frontend/app/[locale]/methodology/introduction-section.tsx
@@ -1,5 +1,5 @@
-import GenericSection from './generique-component';
+import GenericSection from '../generique-component';
 
 export default function IntroductionSection() {
-  return <GenericSection title={'IntroductionSection'} />;
+  return <GenericSection title={'IntroductionSection'} page={'Methodology'} />;
 }

--- a/frontend/app/[locale]/methodology/introduction-section.tsx
+++ b/frontend/app/[locale]/methodology/introduction-section.tsx
@@ -1,0 +1,5 @@
+import GenericSection from './generique-component';
+
+export default function IntroductionSection() {
+  return <GenericSection title={'IntroductionSection'} />;
+}

--- a/frontend/app/[locale]/methodology/key-results-section.tsx
+++ b/frontend/app/[locale]/methodology/key-results-section.tsx
@@ -1,5 +1,5 @@
-import GenericSection from './generique-component';
+import GenericSection from '../generique-component';
 
 export default function KeyResultsSection() {
-  return <GenericSection title={'      KeyResultsSection '} />;
+  return <GenericSection title={'KeyResultsSection'} page={'Methodology'} />;
 }

--- a/frontend/app/[locale]/methodology/key-results-section.tsx
+++ b/frontend/app/[locale]/methodology/key-results-section.tsx
@@ -1,0 +1,5 @@
+import GenericSection from './generique-component';
+
+export default function KeyResultsSection() {
+  return <GenericSection title={'      KeyResultsSection '} />;
+}

--- a/frontend/app/[locale]/methodology/method-details-section.tsx
+++ b/frontend/app/[locale]/methodology/method-details-section.tsx
@@ -1,0 +1,5 @@
+import GenericSection from './generique-component';
+
+export default function MethodDetailsSection() {
+  return <GenericSection title={'MethodDetailsSection'} />;
+}

--- a/frontend/app/[locale]/methodology/method-details-section.tsx
+++ b/frontend/app/[locale]/methodology/method-details-section.tsx
@@ -1,5 +1,5 @@
-import GenericSection from './generique-component';
+import GenericSection from '../generique-component';
 
 export default function MethodDetailsSection() {
-  return <GenericSection title={'MethodDetailsSection'} />;
+  return <GenericSection title={'MethodDetailsSection'} page={'Methodology'} />;
 }

--- a/frontend/app/[locale]/methodology/page.tsx
+++ b/frontend/app/[locale]/methodology/page.tsx
@@ -1,7 +1,15 @@
-export default async function Method() {
+import HeroSection from './hero-section';
+import IntroductionSection from './introduction-section';
+import MethodDetailsSection from './method-details-section';
+import KeyResultsSection from './key-results-section';
+
+export default async function MethodologyPage() {
   return (
     <>
-      <div>Methodology PAGE</div>
+      <HeroSection />
+      <IntroductionSection />
+      <MethodDetailsSection />
+      <KeyResultsSection />
     </>
   );
 }


### PR DESCRIPTION
## Description
- Preparation of the Methodology and Calculator pages: structure and placeholder components

## Code changes

### Methodology page
- Created 4 components to structure the Methodology page according to the mockup:
  - `HeroSection`
  - `IntroductionSection`
  - `MethodDetailsSection`
  - `KeyResultsSection`
- Added a temporary `GenericSection` component used as a placeholder to visually fill each section.

### Calculator page
- Created 3 components to structure the Calculator page similarly:
  - `CalculatorHeroSection`
  - `MethodDetailsSection`
  - `CallToActionSection`
- These are also placeholder components for visual layout only.

This setup allows the team to work in parallel and progressively replace placeholders with real content.


## How to test
 `npm run dev`

## 
![image](https://github.com/user-attachments/assets/3fd5571f-87fe-4083-9dae-f90797e72daa)
