### PR TITLE
Fix/egg peritonitis

### DIFF
--- a/frontend/app/[locale]/ui/general/home-page/suffering-causes-section.tsx
+++ b/frontend/app/[locale]/ui/general/home-page/suffering-causes-section.tsx
@@ -38,7 +38,7 @@ export default async function SufferingCausesSection() {
           </div>
         </div>
 
-        <div className=" max-w-xl  md:w-1/3 mx-auto">
+        <div className="md:w-1/3 mx-auto">
           <SufferingBox title={t('SufferingCausesSection.box6.title')}>
             {t('SufferingCausesSection.box6.text')}
           </SufferingBox>

--- a/frontend/app/[locale]/ui/general/home-page/suffering-causes-section.tsx
+++ b/frontend/app/[locale]/ui/general/home-page/suffering-causes-section.tsx
@@ -22,7 +22,7 @@ export default async function SufferingCausesSection() {
           </div>
 
           <div className="hidden md:flex justify-center relative">
-            <img src="suffering_logo.PNG" alt="Silhouette d'une poule" className="w-full " />
+            <img src="suffering_logo.PNG" alt="Silhouette d'une poule" className="w-full h-auto object-contain " />
           </div>
 
           <div className="flex flex-col justify-between gap-6 text-left md:w-1/3">


### PR DESCRIPTION
## Description
* Fix the block so that it is aligned with the others when resize the display
![image](https://github.com/user-attachments/assets/e93e1891-ef7e-4384-a4b4-b3c268d24ea8)

* Fix image display at display rezise
![Capture d'écran 2025-06-20 133327](https://github.com/user-attachments/assets/485c16d8-1691-471b-847c-912704d98ea4)


## Code changes

* delete `max-w-xl` for aling this bloc "egg peritonitis"
* add  `h-auto object-contain`  for fix img

## How to test

`npm run dev`
