### PR TITLE
Feature/provide reason why footprint could not be computed

### DIFF
--- a/backend/app/business/open_food_facts/breeding_type_calculator.py
+++ b/backend/app/business/open_food_facts/breeding_type_calculator.py
@@ -8,13 +8,13 @@ from app.enums.open_food_facts.breeding_type_enums import (
     get_cage_regex,
     get_free_range_regex,
 )
-from app.enums.open_food_facts.enums import AnimalType, BroilerChickenBreedingType, LayingHenBreedingType
+from app.enums.open_food_facts.enums import AnimalType, BreedingType, LayingHenBreedingType
 from app.schemas.open_food_facts.external import ProductData
-from app.schemas.open_food_facts.internal import BreedingTypeAndWeight
+from app.schemas.open_food_facts.internal import ProductType
 
 # Types
 PatternType = set[str]
-PatternMap = Dict[LayingHenBreedingType | BroilerChickenBreedingType, PatternType]
+PatternMap = Dict[BreedingType, PatternType]
 AnimalPatternMap = Dict[tuple[str, str], PatternMap]
 
 
@@ -77,73 +77,66 @@ class BreedingTypeCalculator:
     all animals types registered in BreedingPatternsRepository
     """
 
-    def __init__(self, product_data: ProductData):
+    def __init__(self, product_data: ProductData, product_type: ProductType):
         """
-        Initializes the calculator with the given product data.
-        Args :  product_data (ProductData)
+        Initializes the calculator with the given product data
+        and product type computed by the pain report calculator
+        Args :  product_data (ProductData), product_type (ProductType)
         """
         self.product_data = product_data
         self.patterns_repository = BreedingPatternsRepository()
+        self.product_type = product_type
 
-    def get_breeding_types_by_animal(self) -> dict[AnimalType, BreedingTypeAndWeight]:
+    def get_breeding_types_by_animal(self) -> dict[AnimalType, BreedingType]:
         """
-        Get the breeding types for all animal types based on the product data.
+        Get the breeding types for all animal types known in product_type based on the product data.
         This method processes the product data for each animal type, determines if there is a
         unique match for the breeding type, and returns the result.
         Returns:
-            dict[AnimalType, BreedingTypeAndWeight]: A dictionary mapping each animal type to its respective
-            breeding type and weight = 0.
+            dict[AnimalType, BreedingType]: A dictionary mapping each animal type to its respective
+            breeding type
         """
-        breeding_types_by_animal = {}
+        breeding_types_by_animal: dict[AnimalType, BreedingType] = {}
 
-        for animal_type in self.patterns_repository.get_all_patterns():
-            # Temporary fix to compute pain only for single-ingredient products
-            # Skip if the animal type category is not in the product categories_tags
-            if (
-                not self.product_data.categories_tags
-                or animal_type.categories_tags not in self.product_data.categories_tags
-            ):
-                break
-            matched_breeding_types = self._get_breeding_types(animal_type)
-
-            if len(matched_breeding_types) == 1:
-                breeding_types_by_animal[animal_type] = BreedingTypeAndWeight(breeding_type=matched_breeding_types[0])
+        for animal_type in self.product_type.animal_types:
+            breeding_types_by_animal[animal_type] = animal_type.unknown_breeding_type
 
         return breeding_types_by_animal
 
-    def _get_breeding_types(self, animal_type: AnimalType) -> list[LayingHenBreedingType | BroilerChickenBreedingType]:
+    def get_breeding_type(self, animal_type: AnimalType) -> BreedingType:
         """
         Determines the breeding types for a specific animal based on an identification process.
         1st match exact categories_tag - stops if = 1 found  (> 1 => continue process)
         2nd match regex on names - stops if >= 1 found (> 1 =>  stop process - not found)
         3rd match regex on other tags including categories_tags  (> 1 => stop process - not found)
         Args:  animal_type (AnimalType): The type of animal to determine the breeding type for.
-        Returns:  list[LayingHenBreedingType | BroilerChickenBreedingType]: A list of matched breeding types.
+        Returns:  BreedingType : The determined breeding type for the animal, unknown if not found
+        or too many matches
         """
         matched = self._match_from_exact_tags(tag="categories_tags", animal_type=animal_type)
         if len(matched) == 1:
-            breeding_type = matched[0]
-            breeding_type = self._refine_from_country(breeding_type)
-            return [breeding_type]
+            breeding_type = self._refine_from_country(matched[0])
+            return breeding_type
 
         # Continue if no match or many matches on exact categories_tags
+        # If nothing found or too many return unknown
         for step in ["name", "tags"]:
             matched = self._match_from_regex(explored_tags=self._get_tags_to_explore(step), animal_type=animal_type)
-            if matched:
-                breeding_types = [self._refine_from_country(bt) for bt in matched]
-                return breeding_types
-        return []
+            if len(matched) == 1:
+                breeding_type = self._refine_from_country(matched[0])
+                return breeding_type
+            elif len(matched) > 1:
+                return animal_type.unknown_breeding_type
+        return animal_type.unknown_breeding_type
 
-    def _match_from_exact_tags(
-        self, tag: str, animal_type: AnimalType
-    ) -> list[LayingHenBreedingType | BroilerChickenBreedingType]:
+    def _match_from_exact_tags(self, tag: str, animal_type: AnimalType) -> list[BreedingType]:
         """
         Matches breeding types based on one exact tag from product data (only categories_tags possible here).
         Args:
             tag (str): The type of tag to use for matching (e.g., categories_tags).
             animal_type (AnimalType): The animal type to match against.
         Returns:
-            list[LayingHenBreedingType | BroilerChickenBreedingType]: A list of matched breeding types.
+            list[BreedingType]: A list of matched breeding types.
         """
         explored_tags = getattr(self.product_data, tag, None)
         return [
@@ -152,9 +145,7 @@ class BreedingTypeCalculator:
             if explored_tags and any(t in explored_tags for t in tags)
         ]
 
-    def _match_from_regex(
-        self, explored_tags: list[str] | None, animal_type: AnimalType
-    ) -> list[LayingHenBreedingType | BroilerChickenBreedingType]:
+    def _match_from_regex(self, explored_tags: list[str] | None, animal_type: AnimalType) -> list[BreedingType]:
         """
         Matches breeding types using regex patterns applied to given tags
         Args:
@@ -162,7 +153,7 @@ class BreedingTypeCalculator:
             animal_type (AnimalType): The animal type for which to perform regex matching.
         Returns:    list[LayingHenBreedingType | BroilerChickenBreedingType]: A list of matched breeding types.
         """
-        matched: list[LayingHenBreedingType | BroilerChickenBreedingType] = []
+        matched: list[BreedingType] = []
         if not explored_tags:
             return matched
         for breeding_type, pattern_set in self.patterns_repository.get_patterns(animal_type)[("regex", "all")].items():
@@ -191,9 +182,7 @@ class BreedingTypeCalculator:
         else:
             raise ValueError("Invalid step. Use 'name' or 'tags'.")
 
-    def _refine_from_country(
-        self, breeding_type: LayingHenBreedingType | BroilerChickenBreedingType
-    ) -> LayingHenBreedingType | BroilerChickenBreedingType:
+    def _refine_from_country(self, breeding_type: BreedingType) -> BreedingType:
         """
         Refines the breeding type based on country-specific regulations.
         Args:      breeding_type (LayingHenBreedingType | BroilerChickenBreedingType):

--- a/backend/app/business/open_food_facts/egg_weight_calculator.py
+++ b/backend/app/business/open_food_facts/egg_weight_calculator.py
@@ -186,4 +186,4 @@ def calculate_egg_weight(product_data: ProductData) -> float:
     else:
         egg_weight = get_total_egg_weight_from_tags(categories_tags)
 
-    return egg_weight
+    return max(egg_weight, 0)

--- a/backend/app/business/open_food_facts/egg_weight_calculator.py
+++ b/backend/app/business/open_food_facts/egg_weight_calculator.py
@@ -167,7 +167,7 @@ def get_egg_weight_from_product_quantity_and_unit(quantity: float, unit: str) ->
     return 0
 
 
-def calculate_egg_weight(product_data: ProductData) -> float:
+def calculate_egg_weight(product_data: ProductData) -> float | None:
     """
     Calculates the weight of eggs based on the product data.
 
@@ -186,4 +186,7 @@ def calculate_egg_weight(product_data: ProductData) -> float:
     else:
         egg_weight = get_total_egg_weight_from_tags(categories_tags)
 
-    return max(egg_weight, 0)
+    if egg_weight > 0:
+        return egg_weight
+    else:
+        return None

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -7,15 +7,25 @@ from pydantic import HttpUrl, ValidationError
 from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import ResourceNotFoundException
 from app.enums.open_food_facts.enums import AnimalType, PainType
+from app.enums.open_food_facts.panel_texts import (
+    AnimalInfoTexts,
+    DurationTexts,
+    IntensityDefinitionTexts,
+    MainPanelTexts,
+    PanelTextManager,
+    PhysicalPainTexts,
+    PsychologicalPainTexts,
+)
 from app.schemas.open_food_facts.external import ProductData, ProductResponse, ProductResponseSearchALicious
 from app.schemas.open_food_facts.internal import (
     AnimalPainReport,
-    BreedingTypeAndWeight,
+    BreedingType,
     Element,
     KnowledgePanelResponse,
     PainReport,
     Panel,
     PanelElement,
+    ProductError,
     ProductInfo,
     TextElement,
     TitleElement,
@@ -26,7 +36,7 @@ logger = logging.getLogger("app")
 
 async def get_data_from_off_v3(barcode: str, locale: str) -> ProductData:
     """
-    Retrieve useful product data from OFF API v3 to compute the breeding type and the weight of animal product
+    Retrieve useful product data from OFF API v3 to compute the breeding type and the quantity of animal product
 
     If an error occurs, we raise a ResourceNotFoundException to return a clean response to OFF
 
@@ -68,7 +78,7 @@ async def get_data_from_off_v3(barcode: str, locale: str) -> ProductData:
 async def get_data_from_off_search_a_licious(barcode: str, locale: str) -> ProductData:
     """
     Retrieve useful product data from OFF search-a-licious API
-    to compute the breeding type and the weight of animal product
+    to compute the breeding type and the quantity of animal product
 
     If an error occurs, we raise a ResourceNotFoundException to return a clean response to OFF
 
@@ -148,7 +158,9 @@ async def get_pain_report(barcode: str, locale: str) -> PainReport:
     return calculator.get_pain_report()
 
 
-def get_knowledge_panel_response(pain_report: PainReport, translator: Callable) -> KnowledgePanelResponse:
+def get_knowledge_panel_response(
+    pain_report: PainReport, translator: tuple[Callable, Callable]
+) -> KnowledgePanelResponse:
     """
     Create a complete knowledge panel response with all panels related to suffering footprint.
 
@@ -169,7 +181,7 @@ class KnowledgePanelGenerator:
     Class responsible for generating knowledge panel responses based on pain reports.
     """
 
-    def __init__(self, pain_report: PainReport, translator: Callable):
+    def __init__(self, pain_report: PainReport, translator: tuple[Callable, Callable]):
         """
         Initialize the generator with a pain report and translator.
 
@@ -178,65 +190,78 @@ class KnowledgePanelGenerator:
             translator: The translation function to use for i18n
         """
         self.pain_report = pain_report
-        self._ = translator
+        self.text_manager = PanelTextManager(translator)
+        self._ = translator[0]
+        self._n = translator[1]
 
     def get_response(self) -> KnowledgePanelResponse:
         """
         Create a complete knowledge panel response with all suffering footprint panels.
-
+        If pain_report has a product_error, does not include detailed panels.
         Returns:
             A complete KnowledgePanelResponse with all necessary panels
         """
+        panels = {"main": self._create_main_panel()}
+        if not self.pain_report.product_error:
+            panels.update(
+                {
+                    "intensities_definitions": self._create_intensities_definitions_panel(),
+                    "physical_pain": self._create_physical_pain_panel(),
+                    "psychological_pain": self._create_psychological_pain_panel(),
+                }
+            )
+
         return KnowledgePanelResponse(
-            panels={
-                "main": self.create_main_panel(),
-                "intensities_definitions": self.create_intensities_definitions_panel(),
-                "physical_pain": self.create_physical_pain_panel(),
-                "psychological_pain": self.create_psychological_pain_panel(),
-            },
+            panels=panels,
             product=ProductInfo(
                 image_url=self.pain_report.product_image_url,
                 name=self.pain_report.product_name,
             ),
         )
 
-    def create_main_panel(self) -> Panel:
+    def _create_main_panel(self) -> Panel:
         """
         Create the main panel showing general information about the suffering footprint.
 
         This panel includes an explanation of the suffering footprint, the breeding
-        type and animal product weight information, and links to the other panels.
+        type and animal product quantity information, and links to the other panels.
+        It handles different product errors to display appropriate messages.
 
         Returns:
             A panel with general information and links to detailed panels
         """
-        elements = [
-            self._get_text_element(
-                self._(
-                    "The <a href='https://empreinte-souffrance.org/'>Welfare Footprint</a> is calculated based "
-                    "on research from the <a href='https://welfarefootprint.org/'>Welfare Footprint Institute</a> "
-                    "which developed a scientifically rigorous methodology for assessing "
-                    "and quantifying animal welfare in food production systems."
-                )
-            ),
-            self._get_text_element(
-                self._(
-                    "It is unique in providing a comprehensive, biologically meaningful measure of "
-                    "the time animals spend in pain of varying intensities."
-                )
-            ),
-            self._get_text_element(
-                self._(
-                    "The time in pain and details shown below are based on the following data "
-                    "(provided by the Open Food Facts community)"
-                )
-            ),
-        ]
+        match self.pain_report.product_error:
+            case ProductError.NO_HANDLED_ANIMAL:
+                elements = [
+                    self._get_text_element(self.text_manager.get_text(MainPanelTexts.NOT_HANDLED)),
+                ]
+            case ProductError.NO_PAIN_LEVELS:
+                elements = [
+                    self._get_text_element(self.text_manager.get_text(MainPanelTexts.WELFARE_FOOTPRINT_INTRO)),
+                    self._get_text_element(self.text_manager.get_text(MainPanelTexts.WELFARE_FOOTPRINT_UNIQUENESS)),
+                    self._get_text_element(self.text_manager.get_text(MainPanelTexts.MISSING_DATA)),
+                ]
+            case None:
+                elements = [
+                    self._get_text_element(self.text_manager.get_text(MainPanelTexts.WELFARE_FOOTPRINT_INTRO)),
+                    self._get_text_element(self.text_manager.get_text(MainPanelTexts.WELFARE_FOOTPRINT_UNIQUENESS)),
+                    self._get_text_element(self.text_manager.get_text(MainPanelTexts.DATA_BASED_ON)),
+                ]
+            case _:
+                raise ValueError(f"Unknown product error type: {self.pain_report.product_error}")
 
         for animal in self.pain_report.animals:
             elements.append(
                 self._get_text_element(
-                    self._get_breeding_type_and_weight_html(animal.animal_type, animal.breeding_type_with_weight)
+                    self._get_breeding_type_and_quantity_html(
+                        animal.animal_type,
+                        animal.breeding_type_and_quantity.breeding_type
+                        if animal.breeding_type_and_quantity
+                        else animal.breeding_type,
+                        animal.breeding_type_and_quantity.quantity
+                        if animal.breeding_type_and_quantity
+                        else animal.quantity,
+                    )
                 )
             )
 
@@ -255,14 +280,14 @@ class KnowledgePanelGenerator:
                 grade="c",
                 icon_url=HttpUrl("https://iili.io/3o05WOX.png"),
                 name="suffering-footprint",
-                subtitle=self._("What is the welfare footprint?"),
-                title=self._("Welfare footprint"),
+                subtitle=self.text_manager.get_text(MainPanelTexts.PANEL_SUBTITLE),
+                title=self.text_manager.get_text(MainPanelTexts.PANEL_TITLE),
                 type="grade",
             ),
             topics=["suffering-footprint"],
         )
 
-    def create_intensities_definitions_panel(self) -> Panel:
+    def _create_intensities_definitions_panel(self) -> Panel:
         """
         Create a panel explaining the different pain intensity levels.
 
@@ -275,46 +300,21 @@ class KnowledgePanelGenerator:
         """
         return Panel(
             elements=[
-                self._get_text_element(
-                    self._(
-                        "<b>Annoying</b>: Noticeable discomfort that can be ignored. Does not interfere with daily "
-                        "activities or motivated behaviors (exploration, comfort, maintenance). "
-                        "No visible expressions of pain or physiological disturbances."
-                    )
-                ),
-                self._get_text_element(
-                    self._(
-                        "<b>Hurtful</b>: Persistent pain with the possibility of brief moments of forgetting during "
-                        "distractions. Reduces the frequency of motivated behaviors and partially alters functional "
-                        "capabilities, while allowing essential activities to be carried out."
-                    )
-                ),
-                self._get_text_element(
-                    self._(
-                        "<b>Disabling</b>: Constant pain that takes priority over most behaviors. "
-                        "Prevents positive well-being and drastically alters activity level. "
-                        "Requires stronger painkillers and causes inattention to the environment."
-                    )
-                ),
-                self._get_text_element(
-                    self._(
-                        "<b>Excruciating</b>: Extreme unbearable pain, even briefly. "
-                        "In humans, this would mark the threshold of suffering below which many people "
-                        "choose to end their lives rather than endure it. Triggers involuntary manifestations "
-                        "(screams, tremors, extreme agitation) and cannot be relieved."
-                    )
-                ),
+                self._get_text_element(self.text_manager.get_text(IntensityDefinitionTexts.ANNOYING_DEFINITION)),
+                self._get_text_element(self.text_manager.get_text(IntensityDefinitionTexts.HURTFUL_DEFINITION)),
+                self._get_text_element(self.text_manager.get_text(IntensityDefinitionTexts.DISABLING_DEFINITION)),
+                self._get_text_element(self.text_manager.get_text(IntensityDefinitionTexts.EXCRUCIATING_DEFINITION)),
             ],
             level="info",
             title_element=TitleElement(
                 grade="c",
-                title=self._("Intensity categories definitions"),
+                title=self.text_manager.get_text(IntensityDefinitionTexts.PANEL_TITLE),
                 type="grade",
             ),
             topics=["suffering-footprint"],
         )
 
-    def get_animal_pain_for_panel(self, animal_type: AnimalType, pain_type: PainType) -> Element | None:
+    def _get_animal_pain_for_panel(self, animal_type: AnimalType, pain_type: PainType) -> Element | None:
         """
         Create a text element with pain information for a specific animal and pain type.
 
@@ -337,7 +337,7 @@ class KnowledgePanelGenerator:
         # Return the text element
         return self._get_text_element(animal_html)
 
-    def create_physical_pain_panel(self) -> Panel:
+    def _create_physical_pain_panel(self) -> Panel:
         """
         Create a panel displaying physical pain information by animal type.
 
@@ -345,86 +345,57 @@ class KnowledgePanelGenerator:
             A panel with physical pain information organized by animal
         """
         elements = [
-            self._get_text_element(
-                self._(
-                    "<b>Physical pain</b> includes all bodily suffering experienced by animals: "
-                    "fractures, wounds, diseases, breathing difficulties, etc."
-                )
-            ),
-            self._get_text_element(
-                self._(
-                    "The durations below represent the suffering time caused "
-                    "by the production of animal-derived ingredients in this product:"
-                )
-            ),
+            self._get_text_element(self.text_manager.get_text(PhysicalPainTexts.DEFINITION)),
+            self._get_text_element(self.text_manager.get_text(PhysicalPainTexts.DURATION_EXPLANATION)),
         ]
 
         # Add each animal from the pain report
         for animal in self.pain_report.animals:
-            animal_element = self.get_animal_pain_for_panel(animal.animal_type, PainType.PHYSICAL)
+            animal_element = self._get_animal_pain_for_panel(animal.animal_type, PainType.PHYSICAL)
             if animal_element:
                 elements.append(animal_element)
 
         # Add footer
-        elements.append(
-            self._get_text_element(
-                self._(
-                    "You can find more details about the different types of physical suffering "
-                    "<a href='https://empreinte-souffrance.org/'>on our website</a>."
-                )
-            )
-        )
-
-        return Panel(
-            elements=elements,
-            level="info",
-            title_element=TitleElement(grade="c", name="physical-pain", title=self._("Physical pain"), type="grade"),
-            topics=["suffering-footprint"],
-        )
-
-    def create_psychological_pain_panel(self) -> Panel:
-        """
-        Create a panel displaying psychological pain information by animal type.
-
-        Returns:
-            A panel with psychological pain information organized by animal
-        """
-        elements = [
-            self._get_text_element(
-                self._(
-                    "<b>Psychological pain</b> includes mental suffering experienced by animals: "
-                    "stress, anxiety, inability to express natural behaviors, etc."
-                )
-            ),
-            self._get_text_element(
-                self._(
-                    "The durations below represent the suffering time caused "
-                    "by the production of animal-derived ingredients in this product:"
-                )
-            ),
-        ]
-
-        # Add each animal from the pain report
-        for animal in self.pain_report.animals:
-            animal_element = self.get_animal_pain_for_panel(animal.animal_type, PainType.PSYCHOLOGICAL)
-            if animal_element:
-                elements.append(animal_element)
-
-        # Add footer
-        elements.append(
-            self._get_text_element(
-                self._(
-                    "You can find more details about the different types of psychological suffering "
-                    "<a href='https://empreinte-souffrance.org/'>on our website</a>."
-                )
-            )
-        )
+        elements.append(self._get_text_element(self.text_manager.get_text(PhysicalPainTexts.MORE_DETAILS)))
 
         return Panel(
             elements=elements,
             level="info",
             title_element=TitleElement(
-                grade="c", name="psychological-pain", title=self._("Psychological pain"), type="grade"
+                grade="c",
+                name="physical-pain",
+                title=self.text_manager.get_text(PhysicalPainTexts.PANEL_TITLE),
+                type="grade",
+            ),
+            topics=["suffering-footprint"],
+        )
+
+    def _create_psychological_pain_panel(self) -> Panel:
+        """
+        Create a panel displaying psychological pain information by animal type.
+        """
+        elements = [
+            self._get_text_element(self.text_manager.get_text(PsychologicalPainTexts.DEFINITION)),
+            self._get_text_element(self.text_manager.get_text(PsychologicalPainTexts.DURATION_EXPLANATION)),
+        ]
+
+        # Add each animal from the pain report
+        for animal in self.pain_report.animals:
+            animal_element = self._get_animal_pain_for_panel(animal.animal_type, PainType.PSYCHOLOGICAL)
+            if animal_element:
+                elements.append(animal_element)
+
+        # Add footer
+        elements.append(self._get_text_element(self.text_manager.get_text(PsychologicalPainTexts.MORE_DETAILS)))
+
+        return Panel(
+            elements=elements,
+            level="info",
+            title_element=TitleElement(
+                grade="c",
+                name="psychological-pain",
+                title=self.text_manager.get_text(PsychologicalPainTexts.PANEL_TITLE),
+                type="grade",
             ),
             topics=["suffering-footprint"],
         )
@@ -441,63 +412,67 @@ class KnowledgePanelGenerator:
         """
         return Element(element_type="text", text_element=TextElement(html=text))
 
-    def _get_breeding_type_and_weight_html(
-        self, animal_type: AnimalType, breeding_type_with_weight: BreedingTypeAndWeight
+    def _get_breeding_type_and_quantity_html(
+        self, animal_type: AnimalType, breeding_type: BreedingType | None, quantity: float | None
     ) -> str:
         """
-        Format animal type, breeding type and product weight information as HTML.
-
-        Creates a formatted HTML string showing the animal type (e.g., "Poule pondeuse"),
-        the breeding type (e.g., "Cage conventionnelle"), and the weight of animal product
-        in the food item.
-
-        Args:
-            animal_type: The type of animal (e.g., LAYING_HEN)
-            breeding_type_with_weight: Object containing the breeding type and weight data
-
-        Returns:
-            Formatted HTML string with animal information
+        Format animal type, breeding type and product quantity information as HTML.
         """
-        html_template = self._(
-            "<b>{animal_name} :</b><ul>"
-            "<li>Production system: <b>{breeding_type}</b></li>"
-            "<li>Quantity of egg in the product: <b>{weight}g</b></li></ul>"
-        )
-        return html_template.format(
+        return self.text_manager.format_text(
+            AnimalInfoTexts.ANIMAL_INFO_TEMPLATE,
             animal_name=animal_type.translated_name(self._),
-            breeding_type=breeding_type_with_weight.breeding_type.translated_name(self._),
-            weight=int(breeding_type_with_weight.animal_product_weight),
+            breeding_type=breeding_type.translated_name(self._)
+            if breeding_type
+            else self.text_manager.get_text(AnimalInfoTexts.NOT_FOUND),
+            quantity=str(int(quantity)) + self.text_manager.get_text(AnimalInfoTexts.UNIT)
+            if quantity is not None
+            else self.text_manager.get_text(AnimalInfoTexts.NOT_FOUND),
         )
 
     def _format_duration(self, seconds: int) -> str:
         """
         Format a duration in seconds into a human-readable string.
-
-        Converts seconds into a combination of days, hours, minutes and seconds
-        as appropriate.
-
-        Args:
-            seconds: The duration in seconds to format
-
-        Returns:
-            A formatted string like "2 days 5 hours 30 minutes 10 seconds"
         """
         if seconds <= 0:
-            return self._("0 second")
+            return self.text_manager.get_text(DurationTexts.ZERO_SECOND)
 
         minutes, sec = divmod(seconds, 60)
         hours, minutes = divmod(minutes, 60)
         days, hours = divmod(hours, 24)
         parts = []
+
         if days:
-            parts.append(self._("{} day".format(days)) if days == 1 else self._("{} days".format(days)))
+            parts.append(
+                self.text_manager.get_plural_text(DurationTexts.DAY_SINGULAR, DurationTexts.DAY_PLURAL, days).format(
+                    days
+                )
+            )
         if hours:
-            parts.append(self._("{} hour".format(hours)) if hours == 1 else self._("{} hours".format(hours)))
+            parts.append(
+                self.text_manager.get_plural_text(DurationTexts.HOUR_SINGULAR, DurationTexts.HOUR_PLURAL, hours).format(
+                    hours
+                )
+            )
         if minutes:
-            parts.append(self._("{} minute".format(minutes)) if minutes == 1 else self._("{} minutes".format(minutes)))
+            parts.append(
+                self.text_manager.get_plural_text(
+                    DurationTexts.MINUTE_SINGULAR, DurationTexts.MINUTE_PLURAL, minutes
+                ).format(minutes)
+            )
         if sec:
-            parts.append(self._("{} second".format(sec)) if sec == 1 else self._("{} seconds".format(sec)))
-        return " ".join(parts) if parts else self._("0 second")
+            parts.append(
+                self.text_manager.get_plural_text(
+                    DurationTexts.SECOND_SINGULAR, DurationTexts.SECOND_PLURAL, sec
+                ).format(sec)
+            )
+
+        return (
+            " ".join(parts)
+            if parts
+            else self.text_manager.get_plural_text(
+                DurationTexts.SECOND_SINGULAR, DurationTexts.SECOND_PLURAL, 0
+            ).format(0)
+        )
 
     def _generate_animal_pain_html(self, animal_pain_report: AnimalPainReport, pain_type: PainType) -> str:
         """
@@ -518,8 +493,10 @@ class KnowledgePanelGenerator:
             return ""
 
         # Start with animal name and breeding type
+        if not animal_pain_report.breeding_type_and_quantity:
+            raise ValueError("Error in animal pain report")
         animal_type = animal_pain_report.animal_type
-        breeding_type = animal_pain_report.breeding_type_with_weight.breeding_type
+        breeding_type = animal_pain_report.breeding_type_and_quantity.breeding_type
         html_parts = [f"<b>{animal_type.translated_name(self._)} - {breeding_type.translated_name(self._)}</b>"]
 
         # Add pain levels in standardized order

--- a/backend/app/business/open_food_facts/pain_report_calculator.py
+++ b/backend/app/business/open_food_facts/pain_report_calculator.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List
 
 from app.business.open_food_facts.breeding_type_calculator import BreedingTypeCalculator
 from app.business.open_food_facts.egg_weight_calculator import calculate_egg_weight
@@ -6,11 +6,13 @@ from app.config.exceptions import ResourceNotFoundException
 from app.enums.open_food_facts.enums import TIME_IN_PAIN_FOR_100G_IN_SECONDS, AnimalType, PainIntensity, PainType
 from app.schemas.open_food_facts.external import ProductData
 from app.schemas.open_food_facts.internal import (
+    AnimalError,
     AnimalPainReport,
     BreedingType,
-    BreedingTypeAndWeight,
+    BreedingTypeAndQuantity,
     PainLevelData,
     PainReport,
+    ProductError,
     ProductType,
 )
 
@@ -29,12 +31,18 @@ class PainReportCalculator:
         """
         self.product_data = product_data
         self.product_type = self._get_product_type()
-        self.breeding_types_with_weights = self._get_breeding_types_with_weights()
+        self.breeding_types = self._get_breeding_types()
+        self.quantities = self._get_quantities()
+        self.breeding_types_and_quantities = self._get_breeding_types_and_quantities()
 
     def _get_product_type(self) -> ProductType:
         animal_types = set()
         for animal_type in AnimalType:
-            if self.product_data.categories_tags and animal_type.categories_tags in self.product_data.categories_tags:
+            if (
+                animal_type.is_computed
+                and self.product_data.categories_tags
+                and animal_type.categories_tags in self.product_data.categories_tags
+            ):
                 animal_types.add(animal_type)
         if len(animal_types) == 1:
             return ProductType(is_mixed=False, animal_types=animal_types)
@@ -43,47 +51,59 @@ class PainReportCalculator:
 
     def get_pain_report(self) -> PainReport:
         """
-        Generate a pain report based on breeding types and weights.
+        Generate a pain report based on breeding types and quantities.
 
         The report is organized by animal type, with each animal having
         a list of pain levels categorized by pain type (physical/psychological)
         and breeding type information.
 
         Returns:
-            A complete pain report
+            A complete pain report, with error messages for animals as an option
         """
-        if not self.breeding_types_with_weights:
-            raise ResourceNotFoundException("Can't find valid breeding type or animal product weight for this product")
-
         animal_reports = []
+        product_error: ProductError | None = ProductError.NO_HANDLED_ANIMAL
 
         # Process each animal type and its breeding type
-        for animal_type, breeding_type in self.breeding_types_with_weights.items():
-            # Generate all pain levels for this animal
-            pain_levels = self._generate_pain_levels_for_animal(animal_type, breeding_type)
-
-            # Add animal report to the list
-            animal_reports.append(
-                AnimalPainReport(
-                    animal_type=animal_type, pain_levels=pain_levels, breeding_type_with_weight=breeding_type
+        # If unable to compute animal pain report, add error message to animal report
+        for animal_type, breeding_type_and_quantity in self.breeding_types_and_quantities.items():
+            if isinstance(breeding_type_and_quantity, AnimalError):
+                animal_report = AnimalPainReport(
+                    animal_type=animal_type,
+                    animal_error=breeding_type_and_quantity,
+                    breeding_type=self.breeding_types.get(animal_type, None),
+                    quantity=self.quantities.get(animal_type, None),
                 )
-            )
+                product_error = ProductError.NO_PAIN_LEVELS
+
+            else:
+                try:
+                    animal_report = AnimalPainReport(
+                        animal_type=animal_type,
+                        pain_levels=self._generate_pain_levels_for_animal(animal_type, breeding_type_and_quantity),
+                        breeding_type_and_quantity=breeding_type_and_quantity,
+                    )
+                    product_error = None
+                except ResourceNotFoundException:
+                    raise ResourceNotFoundException(f"Unable to generate pain levels for animal {animal_type}")
+
+            animal_reports.append(animal_report)
 
         return PainReport(
             animals=animal_reports,
             product_name=self.product_data.product_name,
             product_image_url=self.product_data.image_url,
+            product_error=product_error,
         )
 
     def _generate_pain_levels_for_animal(
-        self, animal_type: AnimalType, breeding_type: BreedingTypeAndWeight
+        self, animal_type: AnimalType, breeding_type: BreedingTypeAndQuantity
     ) -> List[PainLevelData]:
         """
         Generate pain levels for a specific animal type and breeding type.
 
         Args:
             animal_type: The type of animal
-            breeding_type: The breeding type with weight information
+            breeding_type: The breeding type with quantity information
 
         Returns:
             List of PainLevelData objects for all pain types and intensities
@@ -92,19 +112,19 @@ class PainReportCalculator:
 
         # Process each pain type
         for pain_type in PainType:
-            pain_levels.extend(self._generate_pain_levels_for_type(animal_type, breeding_type, pain_type))
+            pain_levels.extend(self._generate_pain_levels_for_pain_type(animal_type, breeding_type, pain_type))
 
         return pain_levels
 
-    def _generate_pain_levels_for_type(
-        self, animal_type: AnimalType, breeding_type: BreedingTypeAndWeight, pain_type: PainType
+    def _generate_pain_levels_for_pain_type(
+        self, animal_type: AnimalType, breeding_type_and_quantity: BreedingTypeAndQuantity, pain_type: PainType
     ) -> List[PainLevelData]:
         """
         Generate pain levels for a specific animal, breeding type, and pain type.
 
         Args:
             animal_type: The type of animal
-            breeding_type: The breeding type with weight information
+            breeding_type: The breeding type with quantity information
             pain_type: The type of pain (physical or psychological)
 
         Returns:
@@ -116,7 +136,7 @@ class PainReportCalculator:
         for pain_intensity in PainIntensity:
             # Calculate seconds in pain for this animal, pain type, and intensity
             seconds_in_pain = self._calculate_time_in_pain_for_animal_with_type(
-                animal_type, breeding_type, pain_type, pain_intensity
+                animal_type, breeding_type_and_quantity, pain_type, pain_intensity
             )
 
             # Add pain level entry
@@ -126,70 +146,93 @@ class PainReportCalculator:
 
         return pain_levels
 
-    def _get_breeding_types_with_weights(self) -> Dict[AnimalType, BreedingTypeAndWeight]:
+    def _get_breeding_types_and_quantities(self) -> dict[AnimalType, BreedingTypeAndQuantity | AnimalError]:
         """
-        Gets the breeding types and weights from separate methods.
+        Gets the breeding types and quantity from separate methods.
 
         Returns:
-            A dictionary mapping animal types to BreedingTypeAndWeight
-            objects with detected breeding type and weight
+            A dictionary mapping animal types to BreedingTypeAndQuantity
+            objects  or an error containing
+            the missing information for an animal type that was though identified.
         """
 
-        # Get the breeding types
-        breeding_types_by_animal = self._get_breeding_types()
-        weight_by_animal = self._get_weights()
+        breeding_types_by_animal = self.breeding_types
+        quantity_by_animal = self.quantities
 
-        breeding_types_with_weights = {
-            animal_type: BreedingTypeAndWeight(
-                breeding_type=breeding_types_by_animal[animal_type], animal_product_weight=weight_by_animal[animal_type]
-            )
-            for animal_type in self.product_type.animal_types
-        }
+        breeding_types_and_quantities = dict[AnimalType, BreedingTypeAndQuantity | AnimalError]()
 
-        return breeding_types_with_weights
+        for animal_type in self.product_type.animal_types:
+            try:
+                breeding_type = breeding_types_by_animal[animal_type]
+                quantity = quantity_by_animal[animal_type]
 
-    def _get_breeding_types(self) -> Dict[AnimalType, BreedingType]:
+                match (breeding_type, quantity):
+                    case (None, None):
+                        breeding_types_and_quantities[animal_type] = AnimalError.NO_BREEDING_TYPE_AND_NO_QUANTITY
+                    case (None, _):
+                        breeding_types_and_quantities[animal_type] = AnimalError.NO_BREEDING_TYPE
+                    case (_, None):
+                        breeding_types_and_quantities[animal_type] = AnimalError.NO_QUANTITY
+                if breeding_type and quantity is not None:
+                    breeding_types_and_quantities[animal_type] = BreedingTypeAndQuantity(
+                        breeding_type=breeding_type, quantity=quantity
+                    )
+            except KeyError:
+                raise ResourceNotFoundException(
+                    "Missing breeding type or quantity key for animal type: {}".format(animal_type)
+                )
+
+        return breeding_types_and_quantities
+
+    def _get_breeding_types(self) -> dict[AnimalType, BreedingType | None]:
         """
         Compute the breeding types from product data.
         Returns:
-            A dictionary mapping animal types to BreedingTypeAndWeight
+            A dictionary mapping animal types to BreedingType | None
               objects with detected breeding types
         """
         if self.product_type.is_mixed:
             return BreedingTypeCalculator(self.product_data, self.product_type).get_breeding_types_by_animal()
 
         else:
-            animal_type = list(self.product_type.animal_types)[0]
+            try:
+                animal_type = list(self.product_type.animal_types)[0]
+            except IndexError:
+                raise IndexError("Issue with product type : no animal types found but not mixed")
             breeding_type = BreedingTypeCalculator(self.product_data, self.product_type).get_breeding_type(
                 animal_type=animal_type
             )
             return {animal_type: breeding_type}
 
-    def _get_weights(self) -> dict[AnimalType, float]:
+    def _get_quantities(self) -> dict[AnimalType, float | None]:
         """
-        Calculates and returns the weights associated with each animal type
+        Calculates and returns the quantities associated with each animal type
         present in the product.
-        If product mixed or broiler chicken, weight cannot be computed for now
-        For laying hens  uses a dedicated egg weight calculator.
+        Mixed product and broiler chicken quantity cannot be computed for now
+        For laying hens we use a dedicated egg weight calculator.
 
         Returns:
             dict[AnimalType, float]: A dictionary where keys are `AnimalType`
-            instances and values are their associated weights (in grams).
+            instances and values are their associated quantities (in grams).
         """
         if self.product_type.is_mixed:
-            return {animal_type: 0 for animal_type in self.product_type.animal_types}
+            # unable for now to compute mixed product
+            return {animal_type: None for animal_type in self.product_type.animal_types}
         else:
-            animal_type = list(self.product_type.animal_types)[0]
+            try:
+                animal_type = list(self.product_type.animal_types)[0]
+            except IndexError:
+                return {}
             if animal_type == AnimalType.LAYING_HEN:
-                weight = calculate_egg_weight(self.product_data)
-                return {animal_type: weight}
+                quantity = calculate_egg_weight(self.product_data)
+                return {animal_type: quantity}
             else:
-                return {animal_type: 0}
+                return {animal_type: None}
 
     def _calculate_time_in_pain_for_animal_with_type(
         self,
         animal_type: AnimalType,
-        breeding_type_with_weight: BreedingTypeAndWeight,
+        breeding_type_and_quantity: BreedingTypeAndQuantity,
         pain_type: PainType,
         pain_intensity: PainIntensity,
     ) -> int:
@@ -198,24 +241,22 @@ class PainReportCalculator:
 
         Args:
             animal_type: The type of animal
-            breeding_type_with_weight: A BreedingTypeAndWeight object
+            breeding_type_and_quantity: A BreedingTypeAndQuantity object
             pain_type: The type of pain (physical or psychological)
             pain_intensity: Pain intensity (from PainIntensity enum)
 
         Returns:
             Duration of pain in seconds
         """
-        if breeding_type_with_weight.animal_product_weight <= 0:
-            return 0
 
         # Get the time in pain per 100g for this combination of parameters
         # Default to 0 if any level in the hierarchy is missing
         try:
-            breeding_type = breeding_type_with_weight.breeding_type
+            breeding_type = breeding_type_and_quantity.breeding_type
             time_in_pain = TIME_IN_PAIN_FOR_100G_IN_SECONDS[animal_type][breeding_type][pain_type][pain_intensity]  # type: ignore[index]
         except (KeyError, TypeError):
             # This combination of animal, breeding type, pain type, and intensity is not defined
             return 0
 
-        # Scale the time in pain based on the weight of animal product
-        return int(time_in_pain * breeding_type_with_weight.animal_product_weight / 100)
+        # Scale the time in pain based on the quantity of animal product
+        return int(time_in_pain * breeding_type_and_quantity.quantity / 100)

--- a/backend/app/config/i18n.py
+++ b/backend/app/config/i18n.py
@@ -24,11 +24,11 @@ class I18N:
                 translations = gettext.translation("messages", localedir=str(self.locales_dir), languages=[locale])
                 self.translations[locale] = translations
 
-    def get_translator(self, locale: str) -> Callable:
-        """Get the gettext translator for the given locale"""
+    def get_translator(self, locale: str) -> tuple[Callable, Callable]:
+        """Get the gettext translator and ngettext for the given locale"""
         if locale in self.translations:
-            return self.translations[locale].gettext
-        return self.translations[self.default_locale].gettext
+            return self.translations[locale].gettext, self.translations[locale].ngettext
+        return self.translations[self.default_locale].gettext, self.translations[self.default_locale].ngettext
 
     def is_supported_locale(self, locale: str) -> bool:
         """Check if the given locale is supported"""

--- a/backend/app/enums/open_food_facts/breeding_type_enums.py
+++ b/backend/app/enums/open_food_facts/breeding_type_enums.py
@@ -52,138 +52,143 @@ for breeding in BREEDINGS:
     BREEDING_PATTERNS_ALL_LANGUAGES[breeding] = {breeding}
 # Initializes the dictionnary with the basic name of each breeding
 
-BREEDING_PATTERNS_ALL_LANGUAGES["cage"] = {
-    "caged?",  # Anglais, français
-    "батарейна клетка",  # Bulgare
-    "klecovy chov",  # Tchèque
-    "burhons",  # Suédois
-    "hakkikanala",  # Finnois
-    "kavezni uzgoj",  # Croate
-    "chow klatkowy",  # Polonais
-    "in custi",  # Roumain
-    "laikymas narvuose",  # Lituanien
-    "baterijska reja",  # Slovène
-    "trobbija fil gageg",  # Maltais
-    "i gcas",  # Irlandais
-    "sprostu turesana",  # Letton
-    "en jaula",  # Espagnol
-    "puurikana",  # Finnois
-    "buræg",  # Danois
-    "kafighaltung",  # Allemand
-    "klietkovy chov",  # Slovaque
-    "em gaiola",  # Portugais
-    "κλωβοστοιχια",  # Grec
-    "kooi",  # Néerlandais
-    "gabbia",  # Italien
-    "ketreces tartas",  # Hongrois
-}
-BREEDING_PATTERNS_ALL_LANGUAGES["barn"] = {
-    "sprotos",  # Letton
-    "podnog",  # Croate
-    "podestylkoveho",  # Tchèque
-    "barn",  # Anglais
-    "gridas turesana",  # Letton
-    "frigaende inomhus",  # Suédois
-    "podstielkovy chov",  # Slovaque
-    "laikymas ant kraiko",  # Lituanien
-    "en suelo",  # Espagnol
-    "подово отглеждане",  # Bulgare
-    "podni uzgoj",  # Croate
-    "no solo",  # Espagnol
-    "chow sciołkowy",  # Polonais
-    "lattiakanala",  # Finnois
-    "sol",  # Français
-    "alternativ tartas",  # Hongrois
-    "δαπεδο",  # Grec
-    "talna reja",  # Slovène
-    "podestylkovy chov",  # Tchèque
-    "skrabeæg",  # Danois
-    "scharrel",  # Néerlandais
-    "trobbija fl art",  # Maltais
-    "orrekanalad",  # Estonien
-    "ar an urlar",  # Irlandais
-    "a terra",  # Portugais / Italien
-    "boden(haltung)?",  # Allemand
-}
-BREEDING_PATTERNS_ALL_LANGUAGES["free-range"] = {
-    "freilandeier",  # Allemand
-    "plein air",  # Français
-    "ppa",  # Français
-    "pastoreo",  # Espagnol
-    "volneho",  # Tchèque
-    "laikymas laisveje",  # Lituanien
-    "slobodni uzgoj",  # Croate
-    "trobbija ħielsa",  # Maltais
-    "свободно отглеждане",  # Bulgare
-    "aer liber",  # Roumain
-    "free range",  # Anglais
-    "briva turesana",  # Letton
-    "al aire libre",  # Espagnol
-    "vabapidamine",  # Estonien
-    "prosta reja",  # Slovène
-    "ελευθερας βοσκης",  # Grec
-    "szabadtartas",  # Hongrois
-    "frigaende utomhus",  # Suédois
-    "chow wolnowybiegowy",  # Polonais
-    "frilandsæg",  # Danois
-    "freilandhaltung",  # Allemand
-    "ulkokanala",  # Finnois
-    "all aperto",  # Italien
-    "ao ar livre",  # Portugais
-    "vrije uitloop",  # Néerlandais
-    "saorshreabhadh",  # Irlandais
-    "volny vybeh",  # Slovaque
-}
-BREEDING_PATTERNS_ALL_LANGUAGES["organic"] = {
-    "ออร์แกนิค",  # Thaï
-    "ecologic[ao]",  # Espagnol / Italien
-    "bioeier",  # Allemand
-    "bios?",  # Français
-    "biologico?",  # Italien, Anglais
-    "biologiques?",  # Français
-    "biologis?che?s?",  # Allemand
-    "ekologiku",  # Maltais
-    "luomu",  # Finnois
-    "ecologico",  # Espagnol / Italien
-    "ekoloski",  # Croate
-    "organic",  # Anglais
-    "ekologiska?",  # Suédois
-    "ekologiskais",  # Letton
-    "ecologic",  # Roumain
-    "ekologichen",  # Bulgare
-    "okologiai",  # Hongrois
-    "viologiko",  # Grec
-    "ekologiczny",  # Polonais
-    "organach",  # Irlandais
-    "biologi",  # Danois / Norvégien
-    "ekologiskas",  # Lituanien
-    "oekologisk",  # Danois
-    "oekoloogiline",  # Estonien
-    "ekologicky",  # Tchèque
-    "okologische?n?s?",  # Allemand
-}
-
-BREEDING_PATTERNS_ALL_LANGUAGES["cage-free"] = {
-    "libre de jaula",  # Espagnol
-    "cage free",  # Anglais
-    "vapaan",  # Finnois
-    "libertad",  # Espagnol
-    "libre",  # Espagnol / Français
-    "free run",  # Anglais
-}
-BREEDING_PATTERNS_ALL_LANGUAGES["cage-free"] = {
-    "label rouge"  # Français
-}
-BREEDING_PATTERNS_ALL_LANGUAGES["certified-humane"] = {
-    "certified humane"  # Anglais
-}
-BREEDING_PATTERNS_ALL_LANGUAGES["pastured"] = {
-    "pastured?"  # Anglais
-}
-BREEDING_PATTERNS_ALL_LANGUAGES["biodynamic"] = {
-    "biodynamic",  # Anglais
-    "biodynamique",  # Français
-}
+BREEDING_PATTERNS_ALL_LANGUAGES.update(
+    {
+        "cage": {
+            "caged?",  # Anglais, Français
+            "батарейна клетка",  # Bulgare
+            "klecovy chov",  # Tchèque
+            "burhons",  # Suédois
+            "hakkikanala",  # Finnois
+            "kavezni uzgoj",  # Croate
+            "chow klatkowy",  # Polonais
+            "in custi",  # Roumain
+            "laikymas narvuose",  # Lituanien
+            "baterijska reja",  # Slovène
+            "trobbija fil gageg",  # Maltais
+            "i gcas",  # Irlandais
+            "sprostu turesana",  # Letton
+            "en jaulas?",  # Espagnol
+            "puurikana",  # Finnois
+            "buræg",  # Danois
+            "kafig(haltung)?",  # Allemand
+            "klietkovy chov",  # Slovaque
+            "em gaiola",  # Portugais
+            "κλωβοστοιχια",  # Grec
+            "kooi",  # Néerlandais
+            "gabbia?",  # Italien
+            "ketreces tartas",  # Hongrois
+        },
+        "barn": {
+            "sprotos",  # Letton
+            "podnog",  # Croate
+            "podestylkoveho",  # Tchèque
+            "barn",  # Anglais
+            "gridas turesana",  # Letton
+            "frigaende inomhus",  # Suédois
+            "podstielkovy chov",  # Slovaque
+            "laikymas ant kraiko",  # Lituanien
+            "suelo?",  # Espagnol
+            "подово отглеждане",  # Bulgare
+            "podni uzgoj",  # Croate
+            "no solo",  # Espagnol
+            "chow sciołkowy",  # Polonais
+            "lattiakanala",  # Finnois
+            "sol",  # Français
+            "alternativ tartas",  # Hongrois
+            "δαπεδο",  # Grec
+            "talna reja",  # Slovène
+            "podestylkovy chov",  # Tchèque
+            "skrabeæg",  # Danois
+            "scharrel",  # Néerlandais
+            "trobbija fl art",  # Maltais
+            "orrekanalad",  # Estonien
+            "ar an urlar",  # Irlandais
+            "terra",  # Portugais / Italien
+            "boden(haltung)?",  # Allemand
+            "free run",  # Canada (Anglais)
+        },
+        "free-range": {
+            "freiland(eier)?",  # Allemand
+            "plein air",  # Français
+            "ppa",  # Français (abréviation plein air)
+            "camperas?",  # Espagnol
+            "aire? libre",  # Français / Espagnol
+            "volneho",  # Tchèque
+            "laikymas laisveje",  # Lituanien
+            "slobodni uzgoj",  # Croate
+            "trobbija ħielsa",  # Maltais
+            "свободно отглеждане",  # Bulgare
+            "aer liber",  # Roumain
+            "free range",  # Anglais
+            "briva turesana",  # Letton
+            "al aire libre",  # Espagnol
+            "vabapidamine",  # Estonien
+            "prosta reja",  # Slovène
+            "ελευθερας βοσκης",  # Grec
+            "szabadtartas",  # Hongrois
+            "frigaende utomhus",  # Suédois
+            "chow wolnowybiegowy",  # Polonais
+            "frilandsæg",  # Danois
+            "freilandhaltung",  # Allemand
+            "ulkokanala",  # Finnois
+            "all aperto",  # Italien
+            "ar livre",  # Portugais
+            "vrije uitloop",  # Néerlandais
+            "saorshreabhadh",  # Irlandais
+            "volny vybeh",  # Slovaque
+        },
+        "organic": {
+            "ออร์แกนิค",  # Thaï
+            "ecologic[ao]",  # Espagnol / Italien
+            "bioeier",  # Allemand
+            "bios?",  # Français
+            "biologico?",  # Italien, Anglais
+            "biologiques?",  # Français
+            "biologis?che?s?",  # Allemand
+            "ekologiku",  # Maltais
+            "luomu",  # Finnois
+            "ecologico",  # Espagnol / Italien
+            "ekoloski",  # Croate
+            "organic",  # Anglais
+            "ekologiska?",  # Suédois
+            "ekologiskais",  # Letton
+            "ecologic",  # Roumain
+            "ekologichen",  # Bulgare
+            "okologiai",  # Hongrois
+            "viologiko",  # Grec
+            "ekologiczny",  # Polonais
+            "organach",  # Irlandais
+            "biologi",  # Danois / Norvégien
+            "ekologiskas",  # Lituanien
+            "oekologisk",  # Danois
+            "oekoloogiline",  # Estonien
+            "ekologicky",  # Tchèque
+            "okologische?n?s?",  # Allemand
+        },
+        "cage-free": {
+            "libre de jaula",  # Espagnol
+            "cage free",  # Anglais
+            "vapaan",  # Finnois
+            "libertad",  # Espagnol
+            "libre",  # Espagnol / Français
+        },
+        "label-rouge": {
+            "label rouge",  # Français
+        },
+        "certified-humane": {
+            "certified humane",  # Anglais
+        },
+        "pastured": {
+            "pastured?",  # Anglais
+            "pastoreo",  # Espagnol
+        },
+        "biodynamic": {
+            "biodynamic",  # Anglais
+            "biodynamique",  # Français
+        },
+    }
+)
 
 
 EXCLUDED_PATTERNS: dict[str, set] = {}
@@ -194,21 +199,23 @@ for breeding in BREEDINGS:
     EXCLUDED_PATTERNS[breeding] = set()
 # Initializes each breeding with an empty set
 
-EXCLUDED_PATTERNS["cage"] = {
-    r"\b(cage free)\b",  # English
-    r"\b(hors|pas|non|sans)\b.*\b(cage)\b",  # French
-}
-
-EXCLUDED_PATTERNS["free-range"] = {
-    r"\b(no[tn]?)\b.*\b(free range)\b",  # English
-    r"\b(sans|pas|non?)\b.*\b(plein air)\b",  # French
-}
-
-EXCLUDED_PATTERNS["organic"] = {
-    r"\b(no[tn]?)\b.*\b(organic)\b",  # English
-    r"\b(sans|pas|no[tn]?)\b.*\b(bios?)\b",  # English/French
-    r"\b(sans|pas|non?)\b.*\b(biologiques?)\b",  # French
-}
+EXCLUDED_PATTERNS.update(
+    {
+        "cage": {
+            r"\b(cage free)\b",  # English
+            r"\b(hors|pas|non|sans)\b.*\b(cage)\b",  # French
+        },
+        "free-range": {
+            r"\b(no[tn]?|could|can)\b.*\b(free range)\b",  # English
+            r"\b(sans|pas|non?|peuvent)\b.*\b(plein air)\b",  # French
+        },
+        "organic": {
+            r"\b(no[tn]?)\b.*\b(organic)\b",  # English
+            r"\b(sans|pas|no[tn]?)\b.*\b(bios?)\b",  # English/French
+            r"\b(sans|pas|non?)\b.*\b(biologiques?)\b",  # French
+        },
+    }
+)
 
 
 def get_free_range_regex() -> str:
@@ -248,7 +255,7 @@ def get_barn_regex() -> str:
     Returns:
         str: A regex pattern that matches any of the 'barn' breeding types.
     """
-    return r"^.*\b(" + r")|(".join(BREEDING_PATTERNS_ALL_LANGUAGES["barn"]) + r")\b"
+    return r"^.*\b(" + r"|".join(BREEDING_PATTERNS_ALL_LANGUAGES["barn"]) + r")\b"
 
 
 def get_cage_regex() -> str:

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -9,7 +9,6 @@ class LayingHenBreedingType(StrEnum):
     FURNISHED_CAGE = auto()
     BARN = auto()
     FREE_RANGE = auto()
-    UNKNOWN = auto()
 
     def translated_name(self, _: Callable) -> str:
         """Return the human-readable name for this breeding type"""
@@ -19,20 +18,17 @@ class LayingHenBreedingType(StrEnum):
             "furnished_cage": _("Furnished cage"),
             "barn": _("Barn"),
             "free_range": _("Free range"),
-            "unknown": _("Unknown breeding type"),
         }
         return mappings.get(self.value, self.value)
 
 
 class BroilerChickenBreedingType(StrEnum):
     FREE_RANGE = auto()
-    UNKNOWN = auto()
 
     def translated_name(self, _: Callable) -> str:
         """Return the human-readable name for this breeding type"""
         mappings = {
             "free_range": _("Free range"),
-            "unknown": _("Unknown breeding type"),
         }
         return mappings.get(self.value, self.value)
 
@@ -46,25 +42,20 @@ class AnimalType(StrEnum):
 
     @property
     def categories_tags(self) -> str:
-        """
-        Returns the categories_tags string associated with the animal type.
-        """
-        return {AnimalType.LAYING_HEN: "en:chicken-eggs", AnimalType.BROILER_CHICKEN: "en:chickens"}.get(self) or (
-            _ for _ in ()
-        ).throw(ValueError(f"Unknown animal type: {self.value}"))
+        return {
+            "laying_hen": "en:chicken-eggs",
+            "broiler_chicken": "en:chickens",
+        }.get(self.value) or (_ for _ in ()).throw(ValueError(f"Unknown animal type: {self.value}"))
 
     @property
-    def unknown_breeding_type(self) -> BreedingType:
-        """
-        Returns the categories_tags string associated with the animal type.
-        """
-        unknown_breeding_types: dict[AnimalType, BreedingType] = {
-            AnimalType.LAYING_HEN: LayingHenBreedingType.UNKNOWN,
-            AnimalType.BROILER_CHICKEN: BroilerChickenBreedingType.UNKNOWN,
-        }
-        return unknown_breeding_types.get(self) or (_ for _ in ()).throw(
-            ValueError(f"Unknown animal type: {self.value}")
-        )
+    def is_computed(self) -> bool:
+        result = {
+            "laying_hen": True,
+            "broiler_chicken": False,
+        }.get(self.value)
+        if result is None:
+            raise ValueError(f"Unknown animal type: {self.value}")
+        return result
 
     def translated_name(self, _: Callable) -> str:
         """Return the human-readable name for this animal type"""

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -1,5 +1,43 @@
 from collections.abc import Callable
 from enum import StrEnum, auto
+from typing import TypeAlias
+
+
+class LayingHenBreedingType(StrEnum):
+    CAGE = auto()
+    CONVENTIONAL_CAGE = auto()
+    FURNISHED_CAGE = auto()
+    BARN = auto()
+    FREE_RANGE = auto()
+    UNKNOWN = auto()
+
+    def translated_name(self, _: Callable) -> str:
+        """Return the human-readable name for this breeding type"""
+        mappings = {
+            "cage": _("Cage"),
+            "conventional_cage": _("Conventional cage"),
+            "furnished_cage": _("Furnished cage"),
+            "barn": _("Barn"),
+            "free_range": _("Free range"),
+            "unknown": _("Unknown breeding type"),
+        }
+        return mappings.get(self.value, self.value)
+
+
+class BroilerChickenBreedingType(StrEnum):
+    FREE_RANGE = auto()
+    UNKNOWN = auto()
+
+    def translated_name(self, _: Callable) -> str:
+        """Return the human-readable name for this breeding type"""
+        mappings = {
+            "free_range": _("Free range"),
+            "unknown": _("Unknown breeding type"),
+        }
+        return mappings.get(self.value, self.value)
+
+
+BreedingType: TypeAlias = LayingHenBreedingType | BroilerChickenBreedingType
 
 
 class AnimalType(StrEnum):
@@ -11,44 +49,26 @@ class AnimalType(StrEnum):
         """
         Returns the categories_tags string associated with the animal type.
         """
-        if self == AnimalType.LAYING_HEN:
-            return "en:eggs"
-        elif self == AnimalType.BROILER_CHICKEN:
-            return "en:chickens"
-        else:
-            raise ValueError(f"Unknown animal type: {self.value}")
+        return {AnimalType.LAYING_HEN: "en:chicken-eggs", AnimalType.BROILER_CHICKEN: "en:chickens"}.get(self) or (
+            _ for _ in ()
+        ).throw(ValueError(f"Unknown animal type: {self.value}"))
+
+    @property
+    def unknown_breeding_type(self) -> BreedingType:
+        """
+        Returns the categories_tags string associated with the animal type.
+        """
+        unknown_breeding_types: dict[AnimalType, BreedingType] = {
+            AnimalType.LAYING_HEN: LayingHenBreedingType.UNKNOWN,
+            AnimalType.BROILER_CHICKEN: BroilerChickenBreedingType.UNKNOWN,
+        }
+        return unknown_breeding_types.get(self) or (_ for _ in ()).throw(
+            ValueError(f"Unknown animal type: {self.value}")
+        )
 
     def translated_name(self, _: Callable) -> str:
         """Return the human-readable name for this animal type"""
         mappings = {"laying_hen": _("Laying hen"), "broiler_chicken": _("Broiler chicken")}
-        return mappings.get(self.value, self.value)
-
-
-class LayingHenBreedingType(StrEnum):
-    CAGE = auto()
-    CONVENTIONAL_CAGE = auto()
-    FURNISHED_CAGE = auto()
-    BARN = auto()
-    FREE_RANGE = auto()
-
-    def translated_name(self, _: Callable) -> str:
-        """Return the human-readable name for this breeding type"""
-        mappings = {
-            "cage": _("Cage"),
-            "conventional_cage": _("Conventional cage"),
-            "furnished_cage": _("Furnished cage"),
-            "barn": _("Barn"),
-            "free_range": _("Free range"),
-        }
-        return mappings.get(self.value, self.value)
-
-
-class BroilerChickenBreedingType(StrEnum):
-    FREE_RANGE = auto()
-
-    def translated_name(self, _: Callable) -> str:
-        """Return the human-readable name for this breeding type"""
-        mappings = {"free_range": _("Free range")}
         return mappings.get(self.value, self.value)
 
 

--- a/backend/app/enums/open_food_facts/panel_texts.py
+++ b/backend/app/enums/open_food_facts/panel_texts.py
@@ -1,0 +1,155 @@
+from enum import Enum
+from typing import Callable
+
+
+class MainPanelTexts(Enum):
+    """Texts for the main knowledge panel"""
+
+    WELFARE_FOOTPRINT_INTRO = (
+        "The <a href='https://empreinte-souffrance.org/'>Welfare Footprint</a> is calculated based "
+        "on research from the <a href='https://welfarefootprint.org/'>Welfare Footprint Institute</a> "
+        "which developed a scientifically rigorous methodology for assessing "
+        "and quantifying animal welfare in food production systems."
+    )
+
+    WELFARE_FOOTPRINT_UNIQUENESS = (
+        "It is unique in providing a comprehensive, biologically meaningful measure of "
+        "the time animals spend in pain of varying intensities."
+    )
+
+    DATA_BASED_ON = (
+        "The time in pain and details shown below are based on the following data "
+        "(provided by the Open Food Facts community)"
+    )
+
+    MISSING_DATA = (
+        "The time in pain could not be calculated for this product due to missing data "
+        "in the Open Food Facts product description. You can contribute to the Open Food "
+        "Facts community and help us calculate time in pain by filling in the missing information."
+    )
+
+    NOT_HANDLED = "This product does not contain any animal product supported by the Welfare footprint."
+
+    PANEL_TITLE = "Welfare footprint"
+    PANEL_SUBTITLE = "What is the welfare footprint?"
+
+
+class IntensityDefinitionTexts(Enum):
+    """Texts for pain intensity definitions"""
+
+    ANNOYING_DEFINITION = (
+        "<b>Annoying</b>: Noticeable discomfort that can be ignored. Does not interfere with daily "
+        "activities or motivated behaviors (exploration, comfort, maintenance). "
+        "No visible expressions of pain or physiological disturbances."
+    )
+
+    HURTFUL_DEFINITION = (
+        "<b>Hurtful</b>: Persistent pain with the possibility of brief moments of forgetting during "
+        "distractions. Reduces the frequency of motivated behaviors and partially alters functional "
+        "capabilities, while allowing essential activities to be carried out."
+    )
+
+    DISABLING_DEFINITION = (
+        "<b>Disabling</b>: Constant pain that takes priority over most behaviors. "
+        "Prevents positive well-being and drastically alters activity level. "
+        "Requires stronger painkillers and causes inattention to the environment."
+    )
+
+    EXCRUCIATING_DEFINITION = (
+        "<b>Excruciating</b>: Extreme unbearable pain, even briefly. "
+        "In humans, this would mark the threshold of suffering below which many people "
+        "choose to end their lives rather than endure it. Triggers involuntary manifestations "
+        "(screams, tremors, extreme agitation) and cannot be relieved."
+    )
+
+    PANEL_TITLE = "Intensity categories definitions"
+
+
+class PhysicalPainTexts(Enum):
+    """Texts for physical pain panel"""
+
+    DEFINITION = (
+        "<b>Physical pain</b> includes all bodily suffering experienced by animals: "
+        "fractures, wounds, diseases, breathing difficulties, etc."
+    )
+
+    DURATION_EXPLANATION = (
+        "The durations below represent the suffering time caused "
+        "by the production of animal-derived ingredients in this product:"
+    )
+
+    MORE_DETAILS = (
+        "You can find more details about the different types of physical suffering "
+        "<a href='https://empreinte-souffrance.org/'>on our website</a>."
+    )
+
+    PANEL_TITLE = "Physical pain"
+
+
+class PsychologicalPainTexts(Enum):
+    """Texts for psychological pain panel"""
+
+    DEFINITION = (
+        "<b>Psychological pain</b> includes mental suffering experienced by animals: "
+        "stress, anxiety, inability to express natural behaviors, etc."
+    )
+
+    DURATION_EXPLANATION = (
+        "The durations below represent the suffering time caused "
+        "by the production of animal-derived ingredients in this product:"
+    )
+
+    MORE_DETAILS = (
+        "You can find more details about the different types of psychological suffering "
+        "<a href='https://empreinte-souffrance.org/'>on our website</a>."
+    )
+
+    PANEL_TITLE = "Psychological pain"
+
+
+class AnimalInfoTexts(Enum):
+    """Texts for animal information display"""
+
+    ANIMAL_INFO_TEMPLATE = (
+        "<b>{animal_name} :</b><ul>"
+        "<li>Production system: <b>{breeding_type}</b></li>"
+        "<li>Quantity of egg in the product: <b>{quantity}</b></li></ul>"
+    )
+
+    NOT_FOUND = "Not found"
+
+    UNIT = " g"
+
+
+class DurationTexts(Enum):
+    """Texts for duration formatting"""
+
+    ZERO_SECOND = "0 second"
+    DAY_SINGULAR = "{} day"
+    DAY_PLURAL = "{} days"
+    HOUR_SINGULAR = "{} hour"
+    HOUR_PLURAL = "{} hours"
+    MINUTE_SINGULAR = "{} minute"
+    MINUTE_PLURAL = "{} minutes"
+    SECOND_SINGULAR = "{} second"
+    SECOND_PLURAL = "{} seconds"
+
+
+class PanelTextManager:
+    """Helper class to manage panel texts with translation"""
+
+    def __init__(self, translator: tuple[Callable, Callable]):
+        self._ = translator[0]
+        self._n = translator[1]
+
+    def get_text(self, text_enum: Enum) -> str:
+        """Get translated text from enum"""
+        return self._(text_enum.value)
+
+    def get_plural_text(self, text_enum_singular: Enum, text_enum_plural: Enum, count: int) -> str:
+        """Get translated plural text"""
+        return self._n(text_enum_singular.value, text_enum_plural.value, count)
+
+    def format_text(self, text_enum: Enum, **kwargs) -> str:
+        """Get translated text and format it with provided arguments"""
+        return self._(text_enum.value).format(**kwargs)

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -36,6 +36,16 @@ msgid ""
 "(provided by the Open Food Facts community)"
 msgstr ""
 
+msgid ""
+"The time in pain could not be calculated for this product due to missing data "
+"in the Open Food Facts product description. You can contribute to the Open Food "
+"Facts community and help us calculate time in pain by filling in the missing information."
+msgstr ""
+
+msgid "This product does not contain any animal product supported by the Welfare footprint."
+msgstr ""
+
+
 msgid "What is the welfare footprint?"
 msgstr ""
 
@@ -180,4 +190,7 @@ msgid "Physical"
 msgstr ""
 
 msgid "Psychological"
+msgstr ""
+
+msgid "Not found"
 msgstr ""

--- a/backend/app/locales/fr/LC_MESSAGES/messages.po
+++ b/backend/app/locales/fr/LC_MESSAGES/messages.po
@@ -47,6 +47,22 @@ msgstr ""
 "Le temps de souffrance et les détails affichés ci-dessous sont basés sur "
 "les données suivantes (fournies par la communauté Open Food Facts)"
 
+msgid ""
+"The time in pain could not be calculated for this product due to missing data "
+"in the Open Food Facts product description. You can contribute to the Open Food "
+"Facts community and help us calculate time in pain by filling in the missing information."
+msgstr ""
+"Le temps de souffrance n'a pas pu être calculé pour ce produit car des données "
+"sont manquantes dans la fiche produit Open Food Facts. Vous pouvez contribuer "
+"à la communauté Open Food Facts et nous aider à calculer le temps de souffrance "
+"en renseignant les données manquantes."
+
+msgid ""
+"This product does not contain any animal product supported by the Welfare footprint."
+msgstr ""
+"Ce produit ne contient pas de produits animaux gérés par l'Empreinte souffrance"
+
+
 msgid "What is the welfare footprint?"
 msgstr "Qu'est-ce que l'empreinte souffrance ?"
 
@@ -146,50 +162,38 @@ msgstr ""
 msgid "Psychological pain"
 msgstr "Douleur psychologique"
 
+
+
 #, python-brace-format
 msgid ""
 "<b>{animal_name} :</b><ul><li>Production system: "
 "<b>{breeding_type}</b></li><li>Quantity of egg in the product: "
-"<b>{weight}g</b></li></ul>"
+"<b>{quantity}</b></li></ul>"
 msgstr ""
 "<b>{animal_name} :</b><ul><li>Type d'élevage : "
 "<b>{breeding_type}</b></li><li>Quantité d'œuf dans le produit : "
-"<b>{weight}g</b></li></ul>"
-
-msgid "0 second"
-msgstr "0 seconde"
+"<b>{quantity}</b></li></ul>"
 
 #, python-brace-format
 msgid "{} day"
-msgstr "{} jour"
+msgid_plural "{} days"
+msgstr[0] "{} jour"
+msgstr[1] "{} jours"
 
-#, python-brace-format
-msgid "{} days"
-msgstr "{} jours"
-
-#, python-brace-format
 msgid "{} hour"
-msgstr "{} heure"
+msgid_plural "{} hours"
+msgstr[0] "{} heure"
+msgstr[1] "{} heures"
 
-#, python-brace-format
-msgid "{} hours"
-msgstr "{} heures"
-
-#, python-brace-format
 msgid "{} minute"
-msgstr "{} minute"
+msgid_plural "{} minutes"
+msgstr[0] "{} minute"
+msgstr[1] "{} minutes"
 
-#, python-brace-format
-msgid "{} minutes"
-msgstr "{} minutes"
-
-#, python-brace-format
 msgid "{} second"
-msgstr "{} seconde"
-
-#, python-brace-format
-msgid "{} seconds"
-msgstr "{} secondes"
+msgid_plural "{} seconds"
+msgstr[0] "{} seconde"
+msgstr[1] "{} secondes"
 
 msgid "Laying hen"
 msgstr "Poule pondeuse"
@@ -226,3 +230,6 @@ msgstr "Douleur physique"
 
 msgid "Psychological"
 msgstr "Douleur psychologique"
+
+msgid "Not found"
+msgstr "Non trouvé"

--- a/backend/app/locales/fr/LC_MESSAGES/messages.po
+++ b/backend/app/locales/fr/LC_MESSAGES/messages.po
@@ -57,11 +57,8 @@ msgstr ""
 "à la communauté Open Food Facts et nous aider à calculer le temps de souffrance "
 "en renseignant les données manquantes."
 
-msgid ""
-"This product does not contain any animal product supported by the Welfare footprint."
-msgstr ""
-"Ce produit ne contient pas de produits animaux gérés par l'Empreinte souffrance"
-
+msgid "This product does not contain any animal product supported by the Welfare footprint."
+msgstr "Ce produit ne contient pas de produits animaux gérés par l'Empreinte souffrance"
 
 msgid "What is the welfare footprint?"
 msgstr "Qu'est-ce que l'empreinte souffrance ?"

--- a/backend/app/schemas/open_food_facts/external.py
+++ b/backend/app/schemas/open_food_facts/external.py
@@ -11,7 +11,7 @@ class ProductData(BaseModel):
     categories_tags: List[str] | None = None
     labels_tags: List[str] | None = None
     image_url: HttpUrl | None = None
-    product_name: str
+    product_name: str | None = None
     quantity: str | None = None
     product_quantity_unit: str | None = None
     product_quantity: float | None = None

--- a/backend/app/schemas/open_food_facts/internal.py
+++ b/backend/app/schemas/open_food_facts/internal.py
@@ -1,3 +1,4 @@
+from enum import StrEnum, auto
 from typing import Dict, List
 
 from pydantic import BaseModel, HttpUrl
@@ -16,9 +17,21 @@ class ProductType(BaseModel):
 
 
 # Pain report models, used for calculation
-class BreedingTypeAndWeight(BaseModel):
+class BreedingTypeAndQuantity(BaseModel):
     breeding_type: BreedingType
-    animal_product_weight: float = 0  # in grams
+    quantity: float  # in grams
+
+
+class ProductError(StrEnum):
+    NO_PRODUCT = auto()
+    NO_HANDLED_ANIMAL = auto()
+    NO_PAIN_LEVELS = auto()
+
+
+class AnimalError(StrEnum):
+    NO_QUANTITY = auto()
+    NO_BREEDING_TYPE = auto()
+    NO_BREEDING_TYPE_AND_NO_QUANTITY = auto()
 
 
 class PainLevelData(BaseModel):
@@ -29,8 +42,12 @@ class PainLevelData(BaseModel):
 
 class AnimalPainReport(BaseModel):
     animal_type: AnimalType
-    pain_levels: List[PainLevelData]
-    breeding_type_with_weight: BreedingTypeAndWeight
+    pain_levels: List[PainLevelData] = []
+    breeding_type_and_quantity: BreedingTypeAndQuantity | None = None
+    # only used if breeding_type_with_quantity is None
+    breeding_type: BreedingType | None = None
+    quantity: float | None = None
+    animal_error: AnimalError | None = None
 
     def get_pain_levels_by_type(self, pain_type: PainType) -> List[PainLevelData]:
         """Returns the PainLevelData objects for a specific pain type, sorted by intensity"""
@@ -43,9 +60,10 @@ class AnimalPainReport(BaseModel):
 
 
 class PainReport(BaseModel):
-    animals: List[AnimalPainReport]
+    animals: List[AnimalPainReport] = []
     product_name: str | None
     product_image_url: HttpUrl | None = None
+    product_error: ProductError | None = None
 
 
 # Knowledge panel response models

--- a/backend/app/schemas/open_food_facts/internal.py
+++ b/backend/app/schemas/open_food_facts/internal.py
@@ -4,16 +4,20 @@ from pydantic import BaseModel, HttpUrl
 
 from app.enums.open_food_facts.enums import (
     AnimalType,
-    BroilerChickenBreedingType,
-    LayingHenBreedingType,
+    BreedingType,
     PainIntensity,
     PainType,
 )
 
 
+class ProductType(BaseModel):
+    is_mixed: bool
+    animal_types: set[AnimalType]
+
+
 # Pain report models, used for calculation
 class BreedingTypeAndWeight(BaseModel):
-    breeding_type: LayingHenBreedingType | BroilerChickenBreedingType
+    breeding_type: BreedingType
     animal_product_weight: float = 0  # in grams
 
 

--- a/backend/app/schemas/open_food_facts/internal.py
+++ b/backend/app/schemas/open_food_facts/internal.py
@@ -40,7 +40,7 @@ class AnimalPainReport(BaseModel):
 
 class PainReport(BaseModel):
     animals: List[AnimalPainReport]
-    product_name: str
+    product_name: str | None
     product_image_url: HttpUrl | None = None
 
 
@@ -77,7 +77,7 @@ class Panel(BaseModel):
 
 class ProductInfo(BaseModel):
     image_url: HttpUrl | None
-    name: str
+    name: str | None
 
 
 class KnowledgePanelResponse(BaseModel):

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -28,7 +28,7 @@ from app.config.i18n import I18N
 from app.enums.open_food_facts.enums import AnimalType, LayingHenBreedingType, PainIntensity, PainType
 from app.schemas.open_food_facts.external import ProductData
 from app.schemas.open_food_facts.internal import (
-    BreedingTypeAndWeight,
+    BreedingTypeAndQuantity,
     KnowledgePanelResponse,
 )
 
@@ -125,21 +125,23 @@ async def test_get_data_from_off_http_call_exception(get_data_from_off_function:
         (["en:united-states"], LayingHenBreedingType.CONVENTIONAL_CAGE),
     ],
 )
-def test_compute_breeding_types_with_weights(
+def test_get_breeding_types_and_quantities(
     sample_product_data: ProductData,
     countries,
     expected_breeding_types,
 ):
-    """Test computing breeding types with weights"""
+    """Test computing breeding types with quantities"""
     sample_product_data.countries_tags = countries
     calculator = PainReportCalculator(sample_product_data)
 
-    result = calculator._get_breeding_types_with_weights()
+    result = calculator._get_breeding_types_and_quantities()
 
     # product_data fixture contains the `en:cage-chicken-eggs` tag
     assert AnimalType.LAYING_HEN in result
-    assert result[AnimalType.LAYING_HEN].breeding_type == expected_breeding_types
-    assert result[AnimalType.LAYING_HEN].animal_product_weight == 200
+    item = result[AnimalType.LAYING_HEN]
+    assert isinstance(item, BreedingTypeAndQuantity)
+    assert item.breeding_type == expected_breeding_types
+    assert item.quantity == 200
 
 
 def test_get_breeding_types(sample_product_data: ProductData):
@@ -155,10 +157,10 @@ def test_generate_pain_levels_for_type(sample_product_data: ProductData):
 
     calculator = PainReportCalculator(sample_product_data)
 
-    breeding_type = BreedingTypeAndWeight(breeding_type=LayingHenBreedingType.FURNISHED_CAGE, animal_product_weight=200)
+    breeding_type = BreedingTypeAndQuantity(breeding_type=LayingHenBreedingType.FURNISHED_CAGE, quantity=200)
 
     # Test generating physical pain levels
-    physical_pain_levels = calculator._generate_pain_levels_for_type(
+    physical_pain_levels = calculator._generate_pain_levels_for_pain_type(
         AnimalType.LAYING_HEN, breeding_type, PainType.PHYSICAL
     )
 
@@ -169,7 +171,7 @@ def test_generate_pain_levels_for_type(sample_product_data: ProductData):
         assert isinstance(level.seconds_in_pain, int)
 
     # Test generating psychological pain levels
-    psychological_pain_levels = calculator._generate_pain_levels_for_type(
+    psychological_pain_levels = calculator._generate_pain_levels_for_pain_type(
         AnimalType.LAYING_HEN, breeding_type, PainType.PSYCHOLOGICAL
     )
 
@@ -200,28 +202,28 @@ def test_knowledge_panel_generator(
     generator = KnowledgePanelGenerator(pain_report_for_test, translator)
 
     # Test main panel
-    main_panel = generator.create_main_panel()
+    main_panel = generator._create_main_panel()
     assert main_panel.level == "info"
     assert main_panel.title_element.title == "Welfare footprint"
     assert len(main_panel.elements) > 3
 
     # Test intensities definitions panel
-    intensities_panel = generator.create_intensities_definitions_panel()
+    intensities_panel = generator._create_intensities_definitions_panel()
     assert intensities_panel.title_element.title == "Intensity categories definitions"
     assert len(intensities_panel.elements) == 4  # One for each intensity
 
     # Test physical pain panel
-    physical_panel = generator.create_physical_pain_panel()
+    physical_panel = generator._create_physical_pain_panel()
     assert physical_panel.title_element.title == "Physical pain"
     assert len(physical_panel.elements) > 3  # Intro, description, animal pain data, and footer
 
     # Test psychological pain panel
-    psychological_panel = generator.create_psychological_pain_panel()
+    psychological_panel = generator._create_psychological_pain_panel()
     assert psychological_panel.title_element.title == "Psychological pain"
     assert len(psychological_panel.elements) > 3  # Intro, description, animal pain data, and footer
 
     # Test animal pain element generation
-    animal_element = generator.get_animal_pain_for_panel(AnimalType.LAYING_HEN, PainType.PHYSICAL)
+    animal_element = generator._get_animal_pain_for_panel(AnimalType.LAYING_HEN, PainType.PHYSICAL)
     assert animal_element is not None
     assert animal_element.text_element is not None
     assert animal_element.element_type == "text"
@@ -314,8 +316,8 @@ def test_cage_regex(tag, should_match):
         ("extract_digits_product", 6 * AVERAGE_EGG_WEIGHT),
         ("tagged_large_egg_product", 6 * LARGE_EGG_WEIGHT),
         ("product_quantity_with_unit", pytest.approx(0.5 * 453.59, 0.1)),
-        ("unknown_quantity_product", 0),
-        ("no_data_product", 0),
+        ("unknown_quantity_product", None),
+        ("no_data_product", None),
     ],
 )
 def test_calculate_egg_weight(product_fixture, expected_weight, request):

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -242,7 +242,12 @@ def test_get_knowledge_panel_response(pain_report):
 
 @pytest.mark.parametrize(
     "tag,should_match",
-    [("œufs-plein-air-non-bios", True), ("en:free-range-chicken-eggs", True), ("chicken-eggs-not-free-range", False)],
+    [
+        ("œufs-plein-air-non-bios", True),
+        ("en:free-range-chicken-eggs", True),
+        ("chicken-eggs-not-free-range", False),
+        ("Ariaperta uova fresche da galline allevate all'aperto", True),
+    ],
 )
 def test_free_range_regex(tag, should_match):
     pattern = get_free_range_regex()
@@ -255,6 +260,7 @@ def test_free_range_regex(tag, should_match):
         ("œufs élevés AU SOL*", True),
         ("barn-chicken-eggs-not-organic", True),
         ("produit bio", False),
+        ("oeufs solidaires", False),
     ],
 )
 def test_barn_regex(tag, should_match):
@@ -267,6 +273,7 @@ def test_barn_regex(tag, should_match):
     [
         ("eggs-from-caged-hens", True),
         ("Produit hors Cage", False),
+        ("abcagedd", False),
         ("cage-free-chicken-eggs", False),
         ("ces oeufs ne proviennent pas de poules éléveées en CAGE", False),
     ],

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -134,8 +134,7 @@ def test_compute_breeding_types_with_weights(
     sample_product_data.countries_tags = countries
     calculator = PainReportCalculator(sample_product_data)
 
-    breeding_types = calculator._get_breeding_types()
-    result = calculator._get_breeding_types_with_weights(breeding_types)
+    result = calculator._get_breeding_types_with_weights()
 
     # product_data fixture contains the `en:cage-chicken-eggs` tag
     assert AnimalType.LAYING_HEN in result
@@ -148,7 +147,7 @@ def test_get_breeding_types(sample_product_data: ProductData):
     calculator = PainReportCalculator(sample_product_data)
     result = calculator._get_breeding_types()
     assert AnimalType.LAYING_HEN in result
-    assert result[AnimalType.LAYING_HEN].breeding_type == LayingHenBreedingType.FURNISHED_CAGE
+    assert result[AnimalType.LAYING_HEN] == LayingHenBreedingType.FURNISHED_CAGE
 
 
 def test_generate_pain_levels_for_type(sample_product_data: ProductData):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -37,7 +37,7 @@ def sample_product_data() -> ProductData:
     Contains cage chicken eggs category...
     """
     return ProductData(
-        categories_tags=["en:eggs", "cat1", "en:cage-chicken-eggs"],
+        categories_tags=["en:eggs", "en:chicken-eggs", "cat1", "en:cage-chicken-eggs"],
         labels_tags=["label1", "label2"],
         product_name="Fake product name",
         image_url=HttpUrl("https://example.com/image.jpg"),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 from app.enums.open_food_facts.enums import AnimalType, LayingHenBreedingType, PainIntensity, PainType
 from app.main import app
 from app.schemas.open_food_facts.external import ProductData
-from app.schemas.open_food_facts.internal import AnimalPainReport, BreedingTypeAndWeight, PainLevelData, PainReport
+from app.schemas.open_food_facts.internal import AnimalPainReport, BreedingTypeAndQuantity, PainLevelData, PainReport
 
 
 @pytest_asyncio.fixture
@@ -53,11 +53,11 @@ def sample_product_data() -> ProductData:
 
 
 @pytest.fixture
-def laying_hen_breeding_type() -> BreedingTypeAndWeight:
+def laying_hen_breeding_type() -> BreedingTypeAndQuantity:
     """
-    Fixture that provides a sample BreedingTypeAndWeight for laying hens.
+    Fixture that provides a sample BreedingTypeAndQuantity for laying hens.
     """
-    return BreedingTypeAndWeight(breeding_type=LayingHenBreedingType.FURNISHED_CAGE, animal_product_weight=200)
+    return BreedingTypeAndQuantity(breeding_type=LayingHenBreedingType.FURNISHED_CAGE, quantity=200)
 
 
 @pytest.fixture
@@ -86,7 +86,7 @@ def animal_pain_report(laying_hen_breeding_type, pain_levels) -> AnimalPainRepor
     Fixture that provides a sample AnimalPainReport for a laying hen.
     """
     return AnimalPainReport(
-        animal_type=AnimalType.LAYING_HEN, pain_levels=pain_levels, breeding_type_with_weight=laying_hen_breeding_type
+        animal_type=AnimalType.LAYING_HEN, pain_levels=pain_levels, breeding_type_and_quantity=laying_hen_breeding_type
     )
 
 

--- a/frontend/app/[locale]/off/page.tsx
+++ b/frontend/app/[locale]/off/page.tsx
@@ -50,6 +50,8 @@ export default function KnowledgePanel() {
   const [customBarcode, setCustomBarcode] = useState<string>('3256229237063'); // Poultry chicken barcode
   const [productName, setProductName] = useState<string | null>(null);
   const [productImageUrl, setProductImageUrl] = useState<string | null>(null);
+  const [productUrl, setProductUrl] = useState<string | null>(null);
+  const [APIv2URL, setAPIv2URL] = useState<string | null>(null);
   const [showCustomInput, setShowCustomInput] = useState<boolean>(false);
   const [knowledgePanelData, setKnowledgePanelData] = useState<KnowledgePanelData | null>(null);
   const [expandedPanels, setExpandedPanels] = useState<Record<string, boolean>>({});
@@ -84,7 +86,7 @@ export default function KnowledgePanel() {
   const barcodeNames: { [key: string]: string } = {
     '3450970045360': '10 œufs frais calibre moyen - cage France',
     '2000000124898': 'Cage eggs from USA',
-    '8003636004529': "Sans mode d'élevage",
+    '8003636004529': 'Sans quantité',
     '3560071098278': 'Free-range & cage chicken eggs',
     '3270190205685': 'Free-range chicken eggs from France',
     '0605388714565': "Medium grade A eggs - sans mode d'elevage",
@@ -138,7 +140,6 @@ export default function KnowledgePanel() {
     setError(null);
     setProductName(null);
     setProductImageUrl(null);
-
     try {
       const response = await fetch(`http://127.0.0.1:8000/off/v1/knowledge-panel/${barcode}?lang=${locale}`);
 
@@ -156,6 +157,8 @@ export default function KnowledgePanel() {
       if (data.product) {
         setProductName(data.product.name);
         setProductImageUrl(data.product.image_url);
+        setAPIv2URL(`https://world.openfoodfacts.net/api/v2/product/${selectedBarcode}`);
+        setProductUrl(`https://fr.openfoodfacts.org/produit/${selectedBarcode}`);
       }
 
       // Init panels as expanded by default
@@ -286,32 +289,6 @@ export default function KnowledgePanel() {
             </div>
           </form>
         )}
-
-        {selectedBarcode && selectedBarcode !== 'custom' && (
-          <div className="mt-4 pl-4 text-base text-gray-700">
-            {/* OFF product page and API links*/}
-            <p>
-              <a
-                href={`https://fr.openfoodfacts.org/produit/${selectedBarcode}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                fr.openfoodfacts.org/produit/{selectedBarcode}
-              </a>
-            </p>
-            <p className="mb-2">
-              <a
-                href={`https://world.openfoodfacts.net/api/v2/product/${selectedBarcode}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                world.openfoodfacts.net/api/v2/product/{selectedBarcode}
-              </a>
-            </p>
-          </div>
-        )}
       </div>
 
       {/* Product info */}
@@ -331,6 +308,30 @@ export default function KnowledgePanel() {
             )}
             <div className="flex-grow">
               <h2 className="text-xl font-bold">{productName}</h2>
+              {productUrl && (
+                <p>
+                  <a
+                    href={productUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    Fiche produit OpenFoodFacts
+                  </a>
+                </p>
+              )}
+              {APIv2URL && (
+                <p>
+                  <a
+                    href={APIv2URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    API V2 OpenFoodFacts
+                  </a>
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/app/[locale]/off/page.tsx
+++ b/frontend/app/[locale]/off/page.tsx
@@ -40,8 +40,8 @@ type KnowledgePanelData = {
     [key: string]: Panel;
   };
   product?: {
-    name: string;
-    image_url: string;
+    name: string | null;
+    image_url: string | null;
   };
 };
 
@@ -64,18 +64,44 @@ export default function KnowledgePanel() {
     '8003636004529', // no specific category
     '3560071098278', // both en:free-range-chicken-eggs AND en:cage-chicken-eggs
     '3270190205685', // free-range chicken eggs from France
-    '0605388714565 ', // no specific category
+    '0605388714565', // no specific category
     '50326686', // cage chicken eggs from UK
     '4311501688120', // barn chicken eggs from Germany
     '4056489292395 ', // free-range eggs from Germany
     '9413000012057', // free-range eggs from New-Zealand
     '9414674989591', // cage eggs from New-Zealand
     '5202930932252', // free-range eggs, no country
-    '9313715907009', // Poultry chicken barcode
+    '9313715907009', //
     '5010482558413', // cage, France and UK
     '3372140000101', // cage, 2 countries
+    '3302740059193', // broiler chicken
+    '3256229237063',
+    '0451418000005',
+    '3331354307611',
     'custom',
   ];
+
+  const barcodeNames: { [key: string]: string } = {
+    '3450970045360': '10 œufs frais calibre moyen - cage France',
+    '2000000124898': 'Cage eggs from USA',
+    '8003636004529': "Sans mode d'élevage",
+    '3560071098278': 'Free-range & cage chicken eggs',
+    '3270190205685': 'Free-range chicken eggs from France',
+    '0605388714565': "Medium grade A eggs - sans mode d'elevage",
+    '50326686': 'Cage chicken eggs from UK',
+    '4311501688120': 'Barn chicken eggs from Germany',
+    '4056489292395 ': 'Free-range eggs from Germany',
+    '9413000012057': 'Free-range eggs from New-Zealand',
+    '9414674989591': 'Cage eggs from New-Zealand',
+    '5202930932252': 'Free-range eggs, no country',
+    '9313715907009': 'Oeufs cage Australie',
+    '5010482558413': 'Cage, France and UK',
+    '3372140000101': 'Cage, 2 countries',
+    '3302740059193': 'Poulet de chair taggué en:chickens',
+    '3256229237063': 'Poulet de chair non taggué en:chickens',
+    '0451418000005': 'Oeufs barn sans product_name',
+    '3331354307611': 'Oeufs barn et poids sans product_name',
+  };
 
   useEffect(() => {
     if (selectedBarcode && selectedBarcode !== 'custom') {
@@ -227,7 +253,13 @@ export default function KnowledgePanel() {
         >
           {barcodes.map((barcode) => (
             <option key={barcode} value={barcode}>
-              {barcode === 'custom' ? t('KnowledgePanel.otherBarcode') : barcode}
+              {
+                barcode === 'custom'
+                  ? t('KnowledgePanel.otherBarcode') // Si c'est 'custom', affiche le texte traduit
+                  : barcodeNames[barcode] // Vérifie si un nom existe pour ce barcode
+                    ? `${barcode} - ${barcodeNames[barcode]}` // Si oui, affiche "code - nom"
+                    : barcode // Sinon, affiche juste le code
+              }
             </option>
           ))}
         </select>
@@ -254,10 +286,36 @@ export default function KnowledgePanel() {
             </div>
           </form>
         )}
+
+        {selectedBarcode && selectedBarcode !== 'custom' && (
+          <div className="mt-4 pl-4 text-base text-gray-700">
+            {/* OFF product page and API links*/}
+            <p>
+              <a
+                href={`https://fr.openfoodfacts.org/produit/${selectedBarcode}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                fr.openfoodfacts.org/produit/{selectedBarcode}
+              </a>
+            </p>
+            <p className="mb-2">
+              <a
+                href={`https://world.openfoodfacts.net/api/v2/product/${selectedBarcode}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                world.openfoodfacts.net/api/v2/product/{selectedBarcode}
+              </a>
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Product info */}
-      {!isLoading && productName && (
+      {!isLoading && (productName !== null || productImageUrl !== null) && (
         <div className="mb-8 p-4 bg-white rounded-lg border shadow-sm">
           <div className="flex flex-col md:flex-row items-start md:items-center gap-6">
             {productImageUrl && (

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -181,7 +181,7 @@ export default {
     numericBarcodeError: 'Please enter a numeric barcode',
     search: 'Search',
     loading: 'Loading data...',
-    productNotFound: "This product doesn't contain supported animal products",
+    productNotFound: 'This product could not be found',
   },
 
   BookAnnouncement: {
@@ -254,11 +254,14 @@ export default {
         'A scientific project of unprecedented scale, involving almost all research into the welfare of laying hens',
       paragraph1:
         'What does a caged hen experience? How does it differ from a free-range hen? What is the nature and extent of these differences? While it is now possible to precisely compare the carbon footprint of different foods, the "animal suffering" footprint remains unclear.',
-      paragraph2: 'The Welfare Footprint Institute aims to fill this gap by quantifying for the very first time the animal suffering behind a food product: the egg.',
+      paragraph2:
+        'The Welfare Footprint Institute aims to fill this gap by quantifying for the very first time the animal suffering behind a food product: the egg.',
       paragraph3:
         'These results are the result of extensive work between xxx and xxxx, bringing together specialists from xxxx disciplines who analyzed more than xxx studies. This interdisciplinary work resulted in a pioneering methodology for quantifying animal suffering.',
-      scientist_text1: 'Cynthia holds a PhD in Zoology (Animal Behavior and Intelligence) from the University of Oxford. She has developed several research projects for research institutions in the UK, USA, and Brazil, and has written over 70 scientific publications, book chapters, and educational materials.',
-      scientist_text2: 'Wladimir holds a PhD in epidemiology from the University of Oxford, with over 20 years of research experience in evolution, ethology, and global health. He has collaborated with universities worldwide and published over 100 studies in peer-reviewed journals.',
+      scientist_text1:
+        'Cynthia holds a PhD in Zoology (Animal Behavior and Intelligence) from the University of Oxford. She has developed several research projects for research institutions in the UK, USA, and Brazil, and has written over 70 scientific publications, book chapters, and educational materials.',
+      scientist_text2:
+        'Wladimir holds a PhD in epidemiology from the University of Oxford, with over 20 years of research experience in evolution, ethology, and global health. He has collaborated with universities worldwide and published over 100 studies in peer-reviewed journals.',
       list_here: 'list here',
     },
   },

--- a/frontend/locales/fr.ts
+++ b/frontend/locales/fr.ts
@@ -1,10 +1,10 @@
 export default {
   suffering_footprint: 'Empreinte souffrance',
 
-  NavBarLink : {
-    methodology : "Méthodologie",
-    calculator : "Calculateur",
-    about : "A Propos",
+  NavBarLink: {
+    methodology: 'Méthodologie',
+    calculator: 'Calculateur',
+    about: 'A Propos',
   },
 
   GoFurther: {
@@ -181,7 +181,7 @@ export default {
     numericBarcodeError: 'Veuillez saisir un code-barres numérique',
     search: 'Rechercher',
     loading: 'Chargement des données...',
-    productNotFound: 'Ce produit ne contient pas de produits animaux pris en charge',
+    productNotFound: "Ce produit n'a pas pu être trouvé",
   },
 
   BookAnnouncement: {
@@ -202,14 +202,13 @@ export default {
     all_rights_reserved: 'Tous droits réservés',
     graphics: 'Graphisme :',
     rights: ' © 2025 Empreinte Souffrance et Data for Good',
-    by: "par",
-    and: "et",
-    donate: "donnation",
+    by: 'par',
+    and: 'et',
+    donate: 'donnation',
   },
 
-
   // This section is used in the calculator page
-   calculatorPage: {
+  calculatorPage: {
     heroBanner: {
       title: 'Calculateur',
     },
@@ -252,16 +251,18 @@ export default {
     },
     introductionSection: {
       title:
-        'Un projet scientifique d\'ampleur sans précédent, impliquant la quasi-totalité de la recherche en bien-être des poules pondeuses',
+        "Un projet scientifique d'ampleur sans précédent, impliquant la quasi-totalité de la recherche en bien-être des poules pondeuses",
       paragraph1:
-        'Que vit une poule en cage ? Son expérience diffère-t-elle d\'une poule élevée en plein air ? Quelle est la nature et l’ampleur de ces différences ? S\'il est aujourd\'hui possible de comparer précisément l\'empreinte carbone de différents aliments, le flou demeure sur leur empreinte "souffrance animale". ',
+        "Que vit une poule en cage ? Son expérience diffère-t-elle d'une poule élevée en plein air ? Quelle est la nature et l’ampleur de ces différences ? S'il est aujourd'hui possible de comparer précisément l'empreinte carbone de différents aliments, le flou demeure sur leur empreinte \"souffrance animale\". ",
       paragraph2:
         'Le Welfare Footprint Institute vise à combler cette lacune en quantifiant pour la toute première fois la souffrance animale derrière un produit alimentaire : l’œuf.',
-      paragraph3: 'Ces résultats sont le fruit d\'un travail de longue haleine entre xxx et xxxx, réunissant des spécialistes de xxxx disciplines qui ont analysé plus de xxx études. De ce travail interdisciplinaire est née une méthodologie pionnière pour quantifier la souffrance animale.',
-      scientist_text1: 'Cynthia est docteure en zoologie (comportement et intelligence animale) de l\'université d\'Oxford. Elle a développé plusieurs projets de recherche pour des institutions de recherche au Royaume-Uni, aux États-Unis et au Brésil, et a écrit plus de 70 publications scientifiques, chapitres de livres et matériel éducatif.',
-      scientist_text2: 'Wladimir est docteur en épidémiologie de l\'université d\'Oxford, avec plus de 20 ans d\'expérience de recherche en évolution, éthologie et santé mondiale. Il a collaboré avec des universités du monde entier et publié plus de 100 études dans des revues à comité de lecture.',
+      paragraph3:
+        "Ces résultats sont le fruit d'un travail de longue haleine entre xxx et xxxx, réunissant des spécialistes de xxxx disciplines qui ont analysé plus de xxx études. De ce travail interdisciplinaire est née une méthodologie pionnière pour quantifier la souffrance animale.",
+      scientist_text1:
+        "Cynthia est docteure en zoologie (comportement et intelligence animale) de l'université d'Oxford. Elle a développé plusieurs projets de recherche pour des institutions de recherche au Royaume-Uni, aux États-Unis et au Brésil, et a écrit plus de 70 publications scientifiques, chapitres de livres et matériel éducatif.",
+      scientist_text2:
+        "Wladimir est docteur en épidémiologie de l'université d'Oxford, avec plus de 20 ans d'expérience de recherche en évolution, éthologie et santé mondiale. Il a collaboré avec des universités du monde entier et publié plus de 100 études dans des revues à comité de lecture.",
       list_here: 'liste ici',
-    }
-
-  }
+    },
+  },
 } as const;


### PR DESCRIPTION
## Description

- Adjust the `knowledge_panel `display according to an error added to `PainReport ` if product could not be computed (`AnimalPainReport` error to be used later if > 1 product) - error 404 should be returned only when product not found
- Let the `pain_report_calculator` detect product type (mixed or simple) before fetching `quantity `and `breeding_type`
- Replace the concept of weight with a more generic quantity
- Handle products with no `product_name`
- Fix regex bugs for barn and Label Rouge detection
Closes #49, #50, #59, and #60

## Code changes
- Add an `is_computed` property to `AnimalType` to skip computing for certain animals (broiler chicken → False)
- Create `panels_texts.py` to centralize all texts displayed in the knowledge panel
- Add `ProductError` and `AnimalError ` enums
- `breeding_type ` and `quantity ` are returned ` None` when not found

## How to test
Check these products on local/off:

![image](https://github.com/user-attachments/assets/1122f434-dfd5-4ea4-8bf6-6be5a7bc407a)

![image](https://github.com/user-attachments/assets/082e5fa1-aa1b-4ebd-9681-e986b63ba4df)

![image](https://github.com/user-attachments/assets/d4ca2204-a6d0-45bf-977a-b640774aa457)

![image](https://github.com/user-attachments/assets/bab5e1b7-ab5e-450a-85b6-9877d48be2f8)
