### PR TITLE
restore translation for 0 second of pain

### DIFF
--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -121,9 +121,6 @@ msgid ""
 "<b>{weight}g</b></li></ul>"
 msgstr ""
 
-msgid "0 second"
-msgstr ""
-
 #, python-brace-format
 msgid "{} day"
 msgstr ""

--- a/backend/app/locales/fr/LC_MESSAGES/messages.po
+++ b/backend/app/locales/fr/LC_MESSAGES/messages.po
@@ -192,6 +192,9 @@ msgid_plural "{} seconds"
 msgstr[0] "{} seconde"
 msgstr[1] "{} secondes"
 
+msgid "0 second"
+msgstr "0 seconde"
+
 msgid "Laying hen"
 msgstr "Poule pondeuse"
 


### PR DESCRIPTION
## Description

Restore the translation for no pain duration (0 second -> 0 seconde) in the knowledge panel