### PR TITLE
Add a simple cache system for Knowledge Panel endpoint

### DIFF
--- a/backend/app/api/open_food_facts/routes.py
+++ b/backend/app/api/open_food_facts/routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 from starlette.requests import Request
 
 from app.business.open_food_facts.knowledge_panel import get_knowledge_panel_response, get_pain_report
+from app.config.cache import knowledge_panel_cache
 from app.config.exceptions import ExternalServiceException, ResourceNotFoundException
 from app.config.logging import setup_logging
 from app.schemas.open_food_facts.internal import KnowledgePanelResponse
@@ -22,12 +23,26 @@ async def knowledge_panel(request: Request, barcode: str):
     Returns:
         KnowledgePanelResponse: The knowledge panel response.
     """
-    logger.info(f"Getting knowledge panel for product {barcode}")
+    locale = request.state.locale
+    cache_key = f"knowledge_panel:{barcode}:{locale}"
+
+    # Try to get from cache first
+    cached_response = knowledge_panel_cache.get(cache_key)
+    if cached_response is not None:
+        logger.info(f"Returning cached knowledge panel for product {barcode} (locale: {locale})")
+        return cached_response
+
+    logger.info(f"Getting knowledge panel for product {barcode} (locale: {locale})")
 
     try:
-        pain_report = await get_pain_report(barcode=barcode, locale=request.state.locale)
+        pain_report = await get_pain_report(barcode=barcode, locale=locale)
     except (ResourceNotFoundException, ExternalServiceException):
         # Will be handled by the middleware, no need for additional processing here
         raise
 
-    return get_knowledge_panel_response(pain_report=pain_report, translator=request.state.translator)
+    response = get_knowledge_panel_response(pain_report=pain_report, translator=request.state.translator)
+
+    # Cache the response for 1 day (86400 seconds)
+    knowledge_panel_cache.set(cache_key, response, ttl_seconds=86400)
+
+    return response

--- a/backend/app/config/cache.py
+++ b/backend/app/config/cache.py
@@ -1,0 +1,71 @@
+import json
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Optional
+
+
+@dataclass
+class CacheEntry:
+    data: Any
+    timestamp: float
+    ttl_seconds: int
+
+    def is_expired(self) -> bool:
+        return time.time() - self.timestamp > self.ttl_seconds
+
+
+class SimpleCache:
+    """
+    A simple in-memory cache with TTL (Time To Live) support.
+    Thread-safe for concurrent access.
+    """
+
+    def __init__(self):
+        self._cache: dict[str, CacheEntry] = {}
+        self._lock = Lock()
+
+    def _generate_key(self, *args, **kwargs) -> str:
+        """Generate a cache key from arguments."""
+        key_data = {"args": args, "kwargs": kwargs}
+        return json.dumps(key_data, sort_keys=True, default=str)
+
+    def get(self, key: str) -> Optional[Any]:
+        """Get a value from cache if it exists and is not expired."""
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+
+            if entry.is_expired():
+                del self._cache[key]
+                return None
+
+            return entry.data
+
+    def set(self, key: str, value: Any, ttl_seconds: int = 3600) -> None:
+        """Set a value in cache with TTL."""
+        with self._lock:
+            self._cache[key] = CacheEntry(data=value, timestamp=time.time(), ttl_seconds=ttl_seconds)
+
+    def delete(self, key: str) -> bool:
+        """Delete a key from cache. Returns True if key existed."""
+        with self._lock:
+            return self._cache.pop(key, None) is not None
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        with self._lock:
+            self._cache.clear()
+
+    def cleanup_expired(self) -> int:
+        """Remove expired entries. Returns number of entries removed."""
+        with self._lock:
+            expired_keys = [key for key, entry in self._cache.items() if entry.is_expired()]
+            for key in expired_keys:
+                del self._cache[key]
+            return len(expired_keys)
+
+
+# Global cache instance
+knowledge_panel_cache = SimpleCache()

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
+from app.config.cache import knowledge_panel_cache
 from app.schemas.open_food_facts.external import ProductData
 
 
@@ -38,3 +39,112 @@ async def test_get_off_knowledge_panel(async_client: AsyncClient, sample_product
         # Check title element structure
         title_element = panel["title_element"]
         assert "title" in title_element
+
+
+@pytest.mark.asyncio
+async def test_knowledge_panel_cache_miss_then_hit(async_client: AsyncClient, sample_product_data: ProductData):
+    """Test that the cache works correctly: first request is a cache miss, second is a cache hit"""
+    # Clear the cache before testing
+    knowledge_panel_cache.clear()
+
+    mock_response_data = {"product": sample_product_data}
+    mock_response = AsyncMock()
+    mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = AsyncMock(return_value=None)
+
+    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
+        # Get the instance returned by the async context
+        instance = mock_http_client.return_value.__aenter__.return_value
+        instance.get.return_value = mock_response
+
+        # First request - should be a cache miss
+        response1 = await async_client.get("/off/v1/knowledge-panel/123456789")
+        assert response1.status_code == 200
+
+        # Verify the external API was called (cache miss)
+        assert instance.get.called
+        call_count_after_first_request = instance.get.call_count
+
+        # Second request with same barcode - should be a cache hit
+        response2 = await async_client.get("/off/v1/knowledge-panel/123456789")
+        assert response2.status_code == 200
+
+        # Verify the external API was NOT called again (cache hit)
+        assert instance.get.call_count == call_count_after_first_request
+
+        # Verify responses are identical
+        assert response1.json() == response2.json()
+
+
+@pytest.mark.asyncio
+async def test_knowledge_panel_cache_different_locales(async_client: AsyncClient, sample_product_data: ProductData):
+    """Test that cache correctly separates responses by locale"""
+    # Clear the cache before testing
+    knowledge_panel_cache.clear()
+
+    mock_response_data = {"product": sample_product_data}
+    mock_response = AsyncMock()
+    mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = AsyncMock(return_value=None)
+
+    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
+        instance = mock_http_client.return_value.__aenter__.return_value
+        instance.get.return_value = mock_response
+
+        # Request with English locale
+        response_en = await async_client.get("/off/v1/knowledge-panel/123456789", headers={"Accept-Language": "en"})
+        assert response_en.status_code == 200
+        calls_after_en = instance.get.call_count
+
+        # Request with French locale (same barcode) - should trigger new API call
+        response_fr = await async_client.get("/off/v1/knowledge-panel/123456789", headers={"Accept-Language": "fr"})
+        assert response_fr.status_code == 200
+        calls_after_fr = instance.get.call_count
+
+        # Verify both requests triggered API calls (different cache entries)
+        assert calls_after_fr > calls_after_en
+
+        # Third request with English locale - should be cache hit
+        response_en_cached = await async_client.get(
+            "/off/v1/knowledge-panel/123456789", headers={"Accept-Language": "en"}
+        )
+        assert response_en_cached.status_code == 200
+
+        # Verify no additional API call was made (cache hit)
+        assert instance.get.call_count == calls_after_fr
+
+
+@pytest.mark.asyncio
+async def test_knowledge_panel_cache_different_barcodes(async_client: AsyncClient, sample_product_data: ProductData):
+    """Test that cache correctly separates responses by barcode"""
+    # Clear the cache before testing
+    knowledge_panel_cache.clear()
+
+    mock_response_data = {"product": sample_product_data}
+    mock_response = AsyncMock()
+    mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = AsyncMock(return_value=None)
+
+    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
+        instance = mock_http_client.return_value.__aenter__.return_value
+        instance.get.return_value = mock_response
+
+        # First barcode
+        response1 = await async_client.get("/off/v1/knowledge-panel/111111111")
+        assert response1.status_code == 200
+        calls_after_first = instance.get.call_count
+
+        # Different barcode - should trigger new API call
+        response2 = await async_client.get("/off/v1/knowledge-panel/222222222")
+        assert response2.status_code == 200
+        calls_after_second = instance.get.call_count
+
+        # Verify both requests triggered API calls (different cache entries)
+        assert calls_after_second > calls_after_first
+
+        # Same barcode as first request - should be cache hit
+        response1_cached = await async_client.get("/off/v1/knowledge-panel/111111111")
+        assert response1_cached.status_code == 200
+
+        # Verify no additional API call was made (cache hit)
+        assert instance.get.call_count == calls_after_second


### PR DESCRIPTION
## Description

In order to reduce the number of requests to the OFF API, decrease latency, and lighten the overall server workload, we aim to add a caching mechanism to the /knowledge-panel/{barcode} endpoint.

## Code changes

- Added the SimpleCache and CacheEntry classes
- Use a cache TTL of 1 day, based on barcode and locale
- Added tests
 
## How to test

Tests have been provided, but you can call `http://127.0.0.1:8000/off/v1/knowledge-panel/20057206` multiple times and check the logs to see if the cached version is used.