### PR TITLE
Clean the knowledge-panel JSON from null and unused values

### DIFF
--- a/backend/app/api/open_food_facts/routes.py
+++ b/backend/app/api/open_food_facts/routes.py
@@ -11,7 +11,7 @@ router = APIRouter()
 logger = setup_logging()
 
 
-@router.get("/knowledge-panel/{barcode}", response_model=KnowledgePanelResponse)
+@router.get("/knowledge-panel/{barcode}", response_model=KnowledgePanelResponse, response_model_exclude_none=True)
 async def knowledge_panel(request: Request, barcode: str):
     """
     API endpoint to return knowledge panel details.

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -270,12 +270,10 @@ class KnowledgePanelGenerator:
             elements=elements,
             level="info",
             title_element=TitleElement(
-                grade="c",
                 icon_url=HttpUrl("https://iili.io/3o05WOX.png"),
                 name="suffering-footprint",
                 subtitle=self.text_manager.get_text(MainPanelTexts.PANEL_SUBTITLE),
                 title=self.text_manager.get_text(MainPanelTexts.PANEL_TITLE),
-                type="grade",
             ),
             topics=["suffering-footprint"],
         )
@@ -300,9 +298,7 @@ class KnowledgePanelGenerator:
             ],
             level="info",
             title_element=TitleElement(
-                grade="c",
                 title=self.text_manager.get_text(IntensityDefinitionTexts.PANEL_TITLE),
-                type="grade",
             ),
             topics=["suffering-footprint"],
         )
@@ -355,10 +351,8 @@ class KnowledgePanelGenerator:
             elements=elements,
             level="info",
             title_element=TitleElement(
-                grade="c",
                 name="physical-pain",
                 title=self.text_manager.get_text(PhysicalPainTexts.PANEL_TITLE),
-                type="grade",
             ),
             topics=["suffering-footprint"],
         )
@@ -385,10 +379,8 @@ class KnowledgePanelGenerator:
             elements=elements,
             level="info",
             title_element=TitleElement(
-                grade="c",
                 name="psychological-pain",
                 title=self.text_manager.get_text(PsychologicalPainTexts.PANEL_TITLE),
-                type="grade",
             ),
             topics=["suffering-footprint"],
         )

--- a/backend/app/schemas/open_food_facts/internal.py
+++ b/backend/app/schemas/open_food_facts/internal.py
@@ -64,9 +64,7 @@ class Element(BaseModel):
 
 
 class TitleElement(BaseModel):
-    grade: str
     title: str
-    type: str
     subtitle: str | None = None
     name: str | None = None
     icon_url: HttpUrl | None = None


### PR DESCRIPTION
## Description

After [a discussion on the OFF slack](https://openfoodfacts.slack.com/archives/C03LFRKLVBQ/p1742579181988389), some things can be improved in the JSON of our knowledge panel endpoint:

- Remove null values
- Remove grade and type type

## Code changes

- Configured the endpoint to not returns null values
- Removed grade and type from Panel model

## How to test

Access `http://127.0.0.1:8000/off/v1/knowledge-panel/20057206` and check the JSON