### PR TITLE
Feat/display egg number in knowledge panel

### DIFF
--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -15,6 +15,7 @@ from app.enums.open_food_facts.panel_texts import (
     PanelTextManager,
     PhysicalPainTexts,
     PsychologicalPainTexts,
+    QuantityTexts,
 )
 from app.schemas.open_food_facts.external import ProductData, ProductResponse, ProductResponseSearchALicious
 from app.schemas.open_food_facts.internal import (
@@ -405,20 +406,24 @@ class KnowledgePanelGenerator:
         """
         breeding_type = breeding_type_and_quantity.breeding_type
         quantity = breeding_type_and_quantity.quantity
-        if quantity is not None:
-            total_weight = quantity.total_weight
+
+        if breeding_type:
+            breeding_type_text = breeding_type.translated_name(self._)
         else:
-            total_weight = None
+            breeding_type_text = self.text_manager.get_text(AnimalInfoTexts.NOT_FOUND)
+
+        if quantity:
+            quantity_text = quantity.translated_display(
+                _=self._, text_manager=self.text_manager, quantity_texts=QuantityTexts
+            )
+        else:
+            quantity_text = self.text_manager.get_text(AnimalInfoTexts.NOT_FOUND)
 
         return self.text_manager.format_text(
             AnimalInfoTexts.ANIMAL_INFO_TEMPLATE,
             animal_name=animal_type.translated_name(self._),
-            breeding_type=breeding_type.translated_name(self._)
-            if breeding_type
-            else self.text_manager.get_text(AnimalInfoTexts.NOT_FOUND),
-            quantity=str(int(total_weight)) + self.text_manager.get_text(AnimalInfoTexts.UNIT)
-            if total_weight is not None
-            else self.text_manager.get_text(AnimalInfoTexts.NOT_FOUND),
+            breeding_type=breeding_type_text,
+            quantity=quantity_text,
         )
 
     def _format_duration(self, seconds: int) -> str:

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -402,7 +402,19 @@ class KnowledgePanelGenerator:
         self, animal_type: AnimalType, breeding_type_and_quantity: BreedingTypeAndQuantity
     ) -> str:
         """
-        Format animal type, breeding type and product quantity information as HTML.
+        Format animal type, breeding type and product quantity information as HTML,
+        using display methods defined for each object in enums
+
+        Args:
+            animal_type: The type of animal
+            breeding_type_and_quantity: The breeding type and quantity information
+              that can contain None information
+
+        Returns: a formatted HTML string, eg. for laying hens :
+            'Animal type : Laying hen'
+            'Production system: Furnished cage' (or 'Not found')
+            'Quantity of egg in the product: 12 Eggs - Large Caliber'
+              (or 'Not found')
         """
         breeding_type = breeding_type_and_quantity.breeding_type
         quantity = breeding_type_and_quantity.quantity

--- a/backend/app/enums/open_food_facts/enums.py
+++ b/backend/app/enums/open_food_facts/enums.py
@@ -115,6 +115,11 @@ class EggCaliber(StrEnum):
             EggCaliber.EXTRA_LARGE: 78,  # > 73g
         }[self]
 
+    def translated_name(self, _: Callable) -> str:
+        """Return the human-readable caliber"""
+        mappings = {"small": _("Small"), "medium": _("Medium"), "large": _("Large"), "extra_large": _("Extra Large")}
+        return mappings.get(self.value, self.value)
+
 
 @dataclass
 class EggQuantity:
@@ -146,6 +151,25 @@ class EggQuantity:
         egg_weight = caliber.weight if caliber else EggCaliber.AVERAGE.weight
         count = round(total_weight / egg_weight)
         return cls(count=count, total_weight=total_weight, caliber=caliber)
+
+    def translated_display(self, _: Callable, text_manager, quantity_texts) -> str:
+        """Return the human-readable egg quantity
+        Args:
+            text_manager: TextManager instance managing translations with plurals
+            quantity_texts: QuantityTexts enum
+            _: translation function
+
+        Returns:
+            str: Translated human-readable egg quantity eg. "12 Eggs - Large Caliber" or "12 Eggs"
+        """
+        quantity_text = text_manager.get_plural_text(
+            quantity_texts.EGG_SINGULAR, quantity_texts.EGG_PLURAL, self.count
+        ).format(self.count)
+        if self.caliber:
+            quantity_text += " - " + text_manager.get_text(quantity_texts.CALIBER).format(
+                self.caliber.translated_name(_)
+            )
+        return quantity_text
 
 
 ProductQuantity: TypeAlias = EggQuantity

--- a/backend/app/enums/open_food_facts/panel_texts.py
+++ b/backend/app/enums/open_food_facts/panel_texts.py
@@ -111,12 +111,10 @@ class AnimalInfoTexts(Enum):
     ANIMAL_INFO_TEMPLATE = (
         "<b>{animal_name} :</b><ul>"
         "<li>Production system: <b>{breeding_type}</b></li>"
-        "<li>Quantity of egg in the product: <b>{quantity}</b></li></ul>"
+        "<li>Quantity in the product: <b>{quantity}</b></li></ul>"
     )
 
     NOT_FOUND = "Not found"
-
-    UNIT = " g"
 
 
 class DurationTexts(Enum):
@@ -131,6 +129,14 @@ class DurationTexts(Enum):
     MINUTE_PLURAL = "{} minutes"
     SECOND_SINGULAR = "{} second"
     SECOND_PLURAL = "{} seconds"
+
+
+class QuantityTexts(Enum):
+    """Texts for quantity formatting"""
+
+    EGG_SINGULAR = "{} Egg"
+    EGG_PLURAL = "{} Eggs"
+    CALIBER = "{} Caliber"
 
 
 class PanelTextManager:

--- a/backend/app/locales/en/LC_MESSAGES/messages.po
+++ b/backend/app/locales/en/LC_MESSAGES/messages.po
@@ -117,7 +117,7 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "<b>{animal_name} :</b><ul><li>Production system: "
-"<b>{breeding_type}</b></li><li>Quantity of egg in the product: "
+"<b>{breeding_type}</b></li><li>Quantity in the product: "
 "<b>{weight}g</b></li></ul>"
 msgstr ""
 
@@ -182,4 +182,26 @@ msgid "Psychological"
 msgstr ""
 
 msgid "Not found"
+msgstr ""
+
+#, python-brace-format
+msgid "{} Egg"
+msgid_plural "{} Eggs"
+msgstr[0] "{} Egg"
+msgstr[1] "{} Eggs"
+
+#, python-brace-format
+msgid "{} Caliber"
+msgstr ""
+
+msgid "Small"
+msgstr ""
+
+msgid "Medium"
+msgstr ""
+
+msgid "Large"
+msgstr ""
+
+msgid "Extra Large"
 msgstr ""

--- a/backend/app/locales/fr/LC_MESSAGES/messages.po
+++ b/backend/app/locales/fr/LC_MESSAGES/messages.po
@@ -164,11 +164,11 @@ msgstr "Douleur psychologique"
 #, python-brace-format
 msgid ""
 "<b>{animal_name} :</b><ul><li>Production system: "
-"<b>{breeding_type}</b></li><li>Quantity of egg in the product: "
+"<b>{breeding_type}</b></li><li>Quantity in the product: "
 "<b>{quantity}</b></li></ul>"
 msgstr ""
 "<b>{animal_name} :</b><ul><li>Type d'élevage : "
-"<b>{breeding_type}</b></li><li>Quantité d'œuf dans le produit : "
+"<b>{breeding_type}</b></li><li>Quantité dans le produit : "
 "<b>{quantity}</b></li></ul>"
 
 #, python-brace-format
@@ -233,3 +233,25 @@ msgstr "Douleur psychologique"
 
 msgid "Not found"
 msgstr "Non trouvé"
+
+#, python-brace-format
+msgid "{} Egg"
+msgid_plural "{} Eggs"
+msgstr[0] "{} Œuf"
+msgstr[1] "{} Œufs"
+
+#, python-brace-format
+msgid "{} Caliber"
+msgstr "Calibre {}"
+
+msgid "Small"
+msgstr "Petit"
+
+msgid "Medium"
+msgstr "Moyen"
+
+msgid "Large"
+msgstr "Gros"
+
+msgid "Extra Large"
+msgstr "Très Gros"

--- a/frontend/app/[locale]/off/page.tsx
+++ b/frontend/app/[locale]/off/page.tsx
@@ -63,6 +63,7 @@ export default function KnowledgePanel() {
   const t = useI18n();
 
   const barcodes = [
+    'custom',
     '3450970045360', // cage eggs from France
     '2000000124898', // cage eggs from usa
     '8003636004529', // no specific category
@@ -82,7 +83,9 @@ export default function KnowledgePanel() {
     '3256229237063',
     '0451418000005',
     '3331354307611',
-    'custom',
+    '78742330808',
+    '5051140152901',
+    '3560071227241',
   ];
 
   const barcodeNames: { [key: string]: string } = {
@@ -105,6 +108,9 @@ export default function KnowledgePanel() {
     '3256229237063': 'Poulet de chair non taggué en:chickens',
     '0451418000005': 'Oeufs barn sans product_name',
     '3331354307611': 'Oeufs barn et poids sans product_name',
+    '78742330808' : '"1 egg" dans quantity',
+    '5051140152901' : '12 large - calibre trouvé',
+    '3560071227241' : '6 moyens - calibre trouvé',
   };
 
   useEffect(() => {
@@ -159,8 +165,8 @@ export default function KnowledgePanel() {
       if (data.product) {
         setProductName(data.product.name);
         setProductImageUrl(data.product.image_url);
-        setAPIv2URL(`https://world.openfoodfacts.net/api/v2/product/${selectedBarcode}`);
-        setProductUrl(`https://fr.openfoodfacts.org/produit/${selectedBarcode}`);
+        setAPIv2URL(`https://world.openfoodfacts.net/api/v2/product/${barcode}`);
+        setProductUrl(`https://fr.openfoodfacts.org/produit/${barcode}`);
       }
 
       // Init panels as expanded by default


### PR DESCRIPTION
## Description

Let the knowledge panel display product quantity as describer in the quantity class
Egg quantity : "12 Large Eggs (- Large Caliber)"

## Code changes

Add display methods in classes EggQuantity and EggCaliber
Use these methods in the knowledge panel
Adapted panel_texts enum file

## How to test

Use the frontend test page to see how quantities are displayed
Python tests should be added to test the knowledge panel html results (#195 created)

Closes #182 
Closes #95 
