### PR TITLE
Fix border color classes

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -62,6 +62,28 @@ html {
   color: var(--brown);
 }
 
+.border-grey {
+    border-color: var(--grey);
+}
+.border-pink-1 {
+    border-color: var(--pink-1);
+}
+.border-pink-2 {
+    border-color: var(--pink-2);
+}
+.border-pink-3 {
+    border-color: var(--pink-3);
+}
+.border-brown {
+    border-color: var(--brown);
+}
+.border-violet-1 {
+    border-color: var(--violet-1);
+}
+.border-violet-2 {
+    border-color: var(--violet-2);
+}
+
 .divide-pink-3 {
   :where(& > :not(:last-child)) {
     border-color: var(--pink-3);


### PR DESCRIPTION
## Description

The border color of discomfort stage in `suffering-stages-description.tsx` component was not working. 
The border was black instead of `pink-2`.

This was due to custom variables not properly working with Tailwind border classes.

The border color now works properly : 
<img width="529" height="383" alt="image" src="https://github.com/user-attachments/assets/69817780-38d9-4a30-9918-73f42d57e89d" />


## Code changes
Declared `border-<var_color>` classes for each color variable.  

## How to test
`cd frontend`
`npm run dev`
