### PR TITLE
update light text color with lightest pink variable.

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -54,7 +54,7 @@ html {
 
 /** -------------------------colors------------------------- **/
 .light-text {
-  color: var(--pink-2);
+  color: var(--pink-1);
 }
 
 .dark-text {


### PR DESCRIPTION
## Description

The `light-text` color was using `pink-2` variable : 
<img width="383" height="265" alt="image" src="https://github.com/user-attachments/assets/a1f9b037-9bfc-4596-810e-484568c60182" />

To be more readable, the font color was updated to a lighter pink variant (`pink-1`)
<img width="470" height="265" alt="image" src="https://github.com/user-attachments/assets/128c3b3e-a2c9-4504-9116-dfe595af750b" />


## Code changes

Using `--pink-1` variable in `light-text` class

## How to test

`cd frontend`
`npm run dev`
