### PR TITLE
Fix/detailed panels building in knowledge panel

### DIFF
--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -210,7 +210,7 @@ class KnowledgePanelGenerator:
         # main panel depending on pain report data and detailed panels
         panels = {"main": self._create_main_panel(detailed_panels)}
 
-        # build detailed panels that where defined before
+        # build detailed panels that where defined
         for panel_name, panel_creator in [
             ("intensities_definitions", self._create_intensities_definitions_panel),
             ("physical_pain", self._create_physical_pain_panel),

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -261,7 +261,7 @@ def test_knowledge_panel_generator(
     generator = KnowledgePanelGenerator(pain_report, translator)
 
     # Test main panel
-    main_panel = generator._create_main_panel()
+    main_panel = generator._create_main_panel(["intensities_definitions", "physical_pain", "psychological_pain"])
     assert main_panel.level == "info"
     assert main_panel.title_element.title == "Welfare footprint"
     assert len(main_panel.elements) > 3
@@ -313,7 +313,7 @@ def test_knowledge_panel_generator_missing_quantity(pain_report_missing_quantity
     generator = KnowledgePanelGenerator(pain_report_missing_quantity, translator)
 
     # Test main panel
-    main_panel = generator._create_main_panel()
+    main_panel = generator._create_main_panel([])
     assert main_panel.level == "info"
     assert main_panel.title_element.title == "Welfare footprint"
 


### PR DESCRIPTION
## Description

Define which detailed panels are to be build in get_response(), then give the list to _create_main_panel() so that it does not add detailed panels that won't be filled in

## How to test

Products with missing information like 8003636004529 should be displayed this way with not error message for unavailable detailed panels

<img width="451" height="365" alt="image" src="https://github.com/user-attachments/assets/5ea1223a-93e8-42ad-9640-501f861999d3" />
