### PR TITLE
Feat/parse egg calibers distinctly from egg count

### DIFF
--- a/backend/app/business/open_food_facts/egg_quantity_calculator.py
+++ b/backend/app/business/open_food_facts/egg_quantity_calculator.py
@@ -34,8 +34,10 @@ class PatternRepository:
         "litres": lambda q: float(q) * 1030,
     }
 
-    # Mapping known category tags to average egg weight in grams
+    # Mapping of egg calibers to known category tags
     EGG_CALIBERS_BY_TAG = {
+        EggCaliber.SMALL: {"en:small-eggs"},
+        EggCaliber.MEDIUM: {"en:medium-eggs-pack-of-10", "en:organic-chicken-eggs-medium-size"},
         EggCaliber.LARGE: {
             "en:large-eggs",
             "en:free-range-organic-large-chicken-eggs",
@@ -43,7 +45,18 @@ class PatternRepository:
             "en:free-range-large-eggs",
             "en:large-free-run-chicken-eggs",
         },
-        EggCaliber.MEDIUM: {"en:medium-eggs-pack-of-10", "en:organic-chicken-eggs-medium-size"},
+        EggCaliber.EXTRA_LARGE: {
+            "en:extra-large-eggs",
+        },
+    }
+
+    # Mapping of egg calibers to regex patterns for product names
+    # TODO : enhance patterns
+    EGG_CALIBERS_BY_EXPRESSION = {
+        EggCaliber.SMALL: {r"\bs\b", r"\bpetits?\b", r"\bsmall\b"},
+        EggCaliber.MEDIUM: {r"\bm\b", r"\bmedium\b", r"\bmoyen\b", r"\bmoyens\b"},
+        EggCaliber.LARGE: {r"\bgros\b", r"\bl\b", r"\bxl\b", r"\blarge\b"},
+        EggCaliber.EXTRA_LARGE: {r"\bxl\b", r"\bextra\b", r"\bextra large\b", r"\bextra-large\b", r"\btrès gros\b"},
     }
 
     # Regex: matches a number alone (e.g. "6")
@@ -76,7 +89,7 @@ class EggQuantityCalculator:
     def __init__(self):
         self.pattern_repository = PatternRepository
 
-    def get_egg_caliber_by_tag(self, categories_tags: List[str]) -> EggCaliber | None:
+    def _get_egg_caliber_from_tags(self, categories_tags: List[str]) -> EggCaliber | None:
         """
         Returns the egg caliber based on category tags.
 
@@ -90,23 +103,21 @@ class EggQuantityCalculator:
                 return caliber
         return None
 
-    def get_number_of_eggs(self, categories_tags: List[str]) -> int:
+    def _get_egg_caliber_from_product_name(self, product_name: str) -> EggCaliber | None:
         """
-        Extracts the number of eggs from categories tags, for now pack size.
-        TODO: Add support for other tags
+        Returns the egg caliber based on the product name.
 
         Args:
-            categories_tags (List[str]): List of category tags from the product data.
+            product_name (str): The name of the product.
         Returns:
-            int: The number of eggs if a number is found, otherwise 0.
+            EggCaliber: The caliber of one egg if a matching tag is found, otherwise None.
         """
-        for tag in categories_tags:
-            match = re.search(r"pack-of-(\d+)", tag)
-            if match:
-                return int(match.group(1))
-        return 0
+        for caliber, expressions in self.pattern_repository.EGG_CALIBERS_BY_EXPRESSION.items():
+            if any(re.search(str, product_name, re.IGNORECASE) for str in expressions):
+                return caliber
+        return None
 
-    def get_egg_quantity_from_tags(self, categories_tags: List[str]) -> EggQuantity | None:
+    def _get_egg_quantity_from_tags(self, categories_tags: List[str], caliber: EggCaliber | None) -> EggQuantity | None:
         """
         Calculates egg quantity based on information found in categories tags.
 
@@ -116,15 +127,15 @@ class EggQuantityCalculator:
             EggQuantity: The calculated egg quantity with count, total weight, and optional caliber,
             or None if no quantity could be found.
         """
-        num_eggs = self.get_number_of_eggs(categories_tags)
-        egg_caliber = self.get_egg_caliber_by_tag(categories_tags)
 
-        if num_eggs == 0:
-            return None
+        for tag in categories_tags:
+            match = re.search(r"pack-of-(\d+)", tag)
+            if match:
+                return EggQuantity.from_count(count=int(match.group(1)), caliber=caliber)
 
-        return EggQuantity.from_count(count=num_eggs, caliber=egg_caliber)
+        return None
 
-    def get_egg_quantity_from_product_quantity(self, quantity: str) -> EggQuantity | None:
+    def _get_egg_quantity_from_product_quantity(self, quantity: str, caliber: EggCaliber | None) -> EggQuantity | None:
         """
         Parses string 'quantity' into egg quantity with count, caliber and weight.
 
@@ -142,7 +153,7 @@ class EggQuantityCalculator:
         if re.fullmatch(self.pattern_repository.REGEX_NUMBERS_ONLY, quantity):
             num = float(quantity)
             if num <= 30:
-                return EggQuantity.from_count(count=int(num))
+                return EggQuantity.from_count(count=int(num), caliber=caliber)
 
         # Case 2: Numeric + unit (Latin, Cyrillic, accented, etc.)
         match = re.match(self.pattern_repository.REGEX_NUMERIC_UNIT, quantity)
@@ -151,41 +162,47 @@ class EggQuantityCalculator:
             unit = match.group(2).lower().split()
             # e.g. '1 dozen'
             if any([u.lower() in self.pattern_repository.DOZEN_EXPRESSIONS for u in unit]):
-                return EggQuantity.from_count(count=int(number * 12))
+                return EggQuantity.from_count(count=int(number * 12), caliber=caliber)
             # e.g. '12 M'
             elif any([u.lower() in self.pattern_repository.MOYEN_EXPRESSIONS for u in unit]):
-                return EggQuantity.from_count(count=int(number), caliber=EggCaliber.MEDIUM)
+                if not caliber:
+                    caliber = EggCaliber.MEDIUM
+                return EggQuantity.from_count(count=int(number), caliber=caliber)
             # e.g. '12 large'
             elif any([u.lower() in self.pattern_repository.LARGE_EXPRESSIONS for u in unit]):
-                return EggQuantity.from_count(count=int(number), caliber=EggCaliber.LARGE)
+                if not caliber:
+                    caliber = EggCaliber.LARGE
+                return EggQuantity.from_count(count=int(number), caliber=caliber)
             else:
                 # e.g. '12 unities'
-                return EggQuantity.from_count(count=int(number))
+                return EggQuantity.from_count(count=int(number), caliber=caliber)
 
         # Case 3: x10 / X10 style
         match = re.match(self.pattern_repository.REGEX_X_NUM, quantity)
         if match:
             egg_number = float(match.group(1))
-            return EggQuantity.from_count(count=int(egg_number))
+            return EggQuantity.from_count(count=int(egg_number), caliber=caliber)
 
         # Case 4: Addition expressions: "10 + 2", "12 + 3 oeufs"
         match = re.search(self.pattern_repository.REGEX_ADDITION, quantity)
         if match:
             egg_number = int(match.group(1)) + int(match.group(2))
-            return EggQuantity.from_count(count=int(egg_number))
+            return EggQuantity.from_count(count=int(egg_number), caliber=caliber)
 
         # Case 5: Single number (e.g. "Boîte de 6")
         match = re.search(self.pattern_repository.REGEX_EXTRACT_DIGITS, quantity)
         if match:
             num = int(match.group(1))
             if num < 1000:
-                return EggQuantity.from_count(count=int(num))
+                return EggQuantity.from_count(count=int(num), caliber=caliber)
 
         # If no patterns matched, return None
         print(f"Could not parse quantity: {quantity}")
         return None
 
-    def get_egg_quantity_from_product_quantity_and_unit(self, quantity: float, unit: str) -> EggQuantity | None:
+    def _get_egg_quantity_from_product_quantity_and_unit(
+        self, quantity: float, unit: str, caliber: EggCaliber | None
+    ) -> EggQuantity | None:
         """
         Converts product quantity and unit (grams or units) into Egg Quantity : weight, count, and caliber.
         If unit is in COUNT_UNITS, quantity is considered as count of eggs.
@@ -201,13 +218,13 @@ class EggQuantityCalculator:
         """
         unit_key = unit.lower()
         if unit in self.pattern_repository.COUNT_UNITS:
-            return EggQuantity.from_count(count=int(quantity))
+            return EggQuantity.from_count(count=int(quantity), caliber=caliber)
         else:
             converter = self.pattern_repository.UNIT_CONVERSIONS.get(unit_key)
             if converter:
                 try:
                     weight = round(converter(quantity))
-                    return EggQuantity.from_weight(total_weight=weight)
+                    return EggQuantity.from_weight(total_weight=weight, caliber=caliber)
                 except (ValueError, TypeError):
                     pass
 
@@ -217,6 +234,8 @@ class EggQuantityCalculator:
     def calculate_egg_quantity(self, product_data: ProductData) -> EggQuantity | None:
         """
         Calculates egg quantity based on the product data.
+        First parses categories tags and product name to determine the egg caliber.
+        Then parses quantity and unit, quantity alone and finally categories tags to get the egg count
 
         Args:
             product_data (ProductData): The product data containing quantity, unit, and categories tags.
@@ -228,10 +247,16 @@ class EggQuantityCalculator:
         unit = product_data.product_quantity_unit
         quantity = product_data.quantity
         categories_tags = product_data.categories_tags or []
+        product_name = product_data.product_name or ""
+
+        caliber = self._get_egg_caliber_from_tags(categories_tags)
+
+        if not caliber:
+            caliber = self._get_egg_caliber_from_product_name(product_name)
 
         if product_quantity and unit:
-            return self.get_egg_quantity_from_product_quantity_and_unit(product_quantity, unit)
+            return self._get_egg_quantity_from_product_quantity_and_unit(product_quantity, unit, caliber)
         elif quantity:
-            return self.get_egg_quantity_from_product_quantity(quantity)
+            return self._get_egg_quantity_from_product_quantity(quantity, caliber)
         else:
-            return self.get_egg_quantity_from_tags(categories_tags)
+            return self._get_egg_quantity_from_tags(categories_tags, caliber)

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -416,7 +416,10 @@ def test_cage_regex(tag, should_match):
     "product_fixture, expected_quantity",
     [
         ("number_only_product", EggQuantity(count=6, total_weight=6 * EggCaliber.AVERAGE.weight)),
-        ("numeric_unit_dozen", EggQuantity(count=12, total_weight=12 * EggCaliber.AVERAGE.weight)),
+        (
+            "numeric_unit_dozen_small",
+            EggQuantity(count=12, total_weight=12 * EggCaliber.SMALL.weight, caliber=EggCaliber.SMALL),
+        ),
         (
             "numeric_unit_moyen",
             EggQuantity(count=12, total_weight=12 * EggCaliber.MEDIUM.weight, caliber=EggCaliber.MEDIUM),
@@ -427,7 +430,10 @@ def test_cage_regex(tag, should_match):
         ),
         ("x_style_product", EggQuantity(count=10, total_weight=10 * EggCaliber.AVERAGE.weight)),
         ("addition_expression_product", EggQuantity(count=12, total_weight=12 * EggCaliber.AVERAGE.weight)),
-        ("extract_digits_product", EggQuantity(count=6, total_weight=6 * EggCaliber.AVERAGE.weight)),
+        (
+            "extract_digits_product_extra_large",
+            EggQuantity(count=6, total_weight=6 * EggCaliber.EXTRA_LARGE.weight, caliber=EggCaliber.EXTRA_LARGE),
+        ),
         (
             "tagged_large_egg_product",
             EggQuantity(count=6, total_weight=6 * EggCaliber.LARGE.weight, caliber=EggCaliber.LARGE),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -200,8 +200,8 @@ def number_only_product():
 
 
 @pytest.fixture
-def numeric_unit_dozen():
-    return ProductData(product_name="Fake product name", quantity="1 dozen")
+def numeric_unit_dozen_small():
+    return ProductData(product_name="Fake product name", quantity="1 dozen", categories_tags=["en:small-eggs"])
 
 
 @pytest.fixture
@@ -216,17 +216,17 @@ def numeric_unit_large():
 
 @pytest.fixture
 def x_style_product():
-    return ProductData(product_name="Fake product name", quantity="x10")
+    return ProductData(product_name="Fake product name l'œuf", quantity="x10")
 
 
 @pytest.fixture
 def addition_expression_product():
-    return ProductData(product_name="Fake product name", quantity="10 + 2")
+    return ProductData(product_name="Fake product name's", quantity="10 + 2")
 
 
 @pytest.fixture
-def extract_digits_product():
-    return ProductData(product_name="Fake product name", quantity="Boîte de 6")
+def extract_digits_product_extra_large():
+    return ProductData(product_name="Fake product name XL", quantity="Boîte de 6")
 
 
 @pytest.fixture
@@ -241,7 +241,9 @@ def product_quantity_with_unit():
 
 @pytest.fixture
 def unknown_quantity_product():
-    return ProductData(product_name="Fake product name", quantity="some weird string")
+    return ProductData(
+        product_name="Fake product name", quantity="some weird string", categories_tags=["en:small-eggs"]
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Make the EggQuantityCalculator first parse egg caliber and then parses egg count
That will let us find more calibers

## Code changes

EggQuantityCalculator : 
- caliber parsing methods were added, successively called while no success
- egg count parsing methods were adapted to include detected caliber

Egg caliber patterns were enriched and precised

## How to test

Tests were adapted
See product 0605388714565

Closes #191 