### PR TITLE
round calculator results

### DIFF
--- a/frontend/app/[locale]/calculator/_components/calculator-select-item.tsx
+++ b/frontend/app/[locale]/calculator/_components/calculator-select-item.tsx
@@ -79,28 +79,28 @@ export default function CalculatorSelect({ quantities, farmings, labels }: Props
 
         <hgroup>
           <h2 className="bg-pink-3 text-center text-3xl sm:text-6xl flex justify-start items-center w-fit">
-            {(data.discomfort * factor).toFixed(1)}
+            {Math.round(data.discomfort * factor)}
           </h2>
           <h3 className="text-xl sm:text-2xl">{labels.discomfort}</h3>
         </hgroup>
 
         <hgroup>
           <h2 className="bg-pink-3 text-center text-3xl sm:text-6xl flex justify-start items-center w-fit">
-            {(data.pain * factor).toFixed(1)}
+            {Math.round(data.pain * factor)}
           </h2>
           <h3 className="text-xl sm:text-2xl"> {labels.pain}</h3>
         </hgroup>
 
         <hgroup>
           <h2 className="bg-pink-3 text-center text-3xl sm:text-6xl flex justify-start items-center w-fit">
-            {(data.intense * factor).toFixed(1)}
+            {Math.round(data.intense * factor)}
           </h2>
           <h3 className="text-xl sm:text-2xl">{labels.intense}</h3>
         </hgroup>
 
         <hgroup>
           <h2 className="bg-pink-3 text-center text-3xl sm:text-6xl flex justify-start items-center w-fit">
-            {(data.agony * factor).toFixed(1)}
+            {Math.round(data.agony * factor)}
           </h2>
           <h3 className="text-xl sm:text-2xl">{labels.agony}.</h3>
         </hgroup>


### PR DESCRIPTION
## Description

Calculator results are always displayed as decimal (`toFixed(1)`).

This mean that full number are also displayed as decimals : "21.0 hours of pain"

It was suggested to remove the decimal notation when the number is full : "21 hours of pain"

However, I think that the decimal notation feels weird for the user in any case, and not only for full number.
For instance, I think it's not natural to understand that "18.4 minutes" means "18 minutes and 24 seconds"

So I suggest to always round the results displayed by the calculator

## Code changes

Numbers displayed by the calculator are now always rounded (no decimal number)

<img width="523" height="493" alt="image" src="https://github.com/user-attachments/assets/5440ccf1-08a6-4f67-8043-4c4b2fdc6196" />


## How to test

`cd frontend`
`npm run dev`
