### PR TITLE
change top panel from main to root in knowledge panel

### DIFF
--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -11,11 +11,11 @@ from app.enums.open_food_facts.panel_texts import (
     AnimalInfoTexts,
     DurationTexts,
     IntensityDefinitionTexts,
-    MainPanelTexts,
     PanelTextManager,
     PhysicalPainTexts,
     PsychologicalPainTexts,
     QuantityTexts,
+    RootPanelTexts,
 )
 from app.schemas.open_food_facts.external import ProductData, ProductResponse, ProductResponseSearchALicious
 from app.schemas.open_food_facts.internal import (
@@ -169,7 +169,7 @@ def get_knowledge_panel_response(
         translator: The translation function to use for i18n
 
     Returns:
-        A complete KnowledgePanelResponse containing main panel, intensity definitions,
+        A complete KnowledgePanelResponse containing root panel, intensity definitions,
         physical pain data and psychological pain data
     """
     panel_generator = KnowledgePanelGenerator(pain_report, translator)
@@ -207,8 +207,8 @@ class KnowledgePanelGenerator:
         else:
             detailed_panels = []
 
-        # main panel depending on pain report data and detailed panels
-        panels = {"main": self._create_main_panel(detailed_panels)}
+        # root panel depending on pain report data and detailed panels
+        panels = {"root": self._create_root_panel(detailed_panels)}
 
         # build detailed panels that where defined
         for panel_name, panel_creator in [
@@ -227,9 +227,9 @@ class KnowledgePanelGenerator:
             ),
         )
 
-    def _create_main_panel(self, detailed_panels: list[str]) -> Panel:
+    def _create_root_panel(self, detailed_panels: list[str]) -> Panel:
         """
-        Create the main panel showing general information about the suffering footprint.
+        Create the root panel showing general information about the suffering footprint.
 
         This panel includes an explanation of the suffering footprint, the breeding
         type and animal product quantity information, and links to the other panels.
@@ -242,17 +242,17 @@ class KnowledgePanelGenerator:
 
         # Initialize the panel with generic information message about the project
         elements = [
-            self._get_text_element(self.text_manager.get_text(MainPanelTexts.WELFARE_FOOTPRINT_INTRO)),
-            self._get_text_element(self.text_manager.get_text(MainPanelTexts.WELFARE_FOOTPRINT_UNIQUENESS)),
+            self._get_text_element(self.text_manager.get_text(RootPanelTexts.WELFARE_FOOTPRINT_INTRO)),
+            self._get_text_element(self.text_manager.get_text(RootPanelTexts.WELFARE_FOOTPRINT_UNIQUENESS)),
         ]
 
         # If all animal pain reports contain no pain levels, add a missing data message
         if all(not animal.pain_levels for animal in animals):
-            elements.append(self._get_text_element(self.text_manager.get_text(MainPanelTexts.MISSING_DATA)))
+            elements.append(self._get_text_element(self.text_manager.get_text(RootPanelTexts.MISSING_DATA)))
 
         # If pain levels are available, add a message explaining suffering is based on breeding type and quantity
         else:
-            elements.append(self._get_text_element(self.text_manager.get_text(MainPanelTexts.DATA_BASED_ON)))
+            elements.append(self._get_text_element(self.text_manager.get_text(RootPanelTexts.DATA_BASED_ON)))
 
         # Add breeding type and quantity from each animal pain report aven if not avalable
         for animal in animals:
@@ -270,15 +270,15 @@ class KnowledgePanelGenerator:
                 ]
             )
 
-        # Create and return the main panel
+        # Create and return the root panel
         return Panel(
             elements=elements,
             level="info",
             title_element=TitleElement(
                 icon_url=HttpUrl("https://iili.io/3o05WOX.png"),
                 name="suffering-footprint",
-                subtitle=self.text_manager.get_text(MainPanelTexts.PANEL_SUBTITLE),
-                title=self.text_manager.get_text(MainPanelTexts.PANEL_TITLE),
+                subtitle=self.text_manager.get_text(RootPanelTexts.PANEL_SUBTITLE),
+                title=self.text_manager.get_text(RootPanelTexts.PANEL_TITLE),
             ),
             topics=["suffering-footprint"],
         )

--- a/backend/app/enums/open_food_facts/panel_texts.py
+++ b/backend/app/enums/open_food_facts/panel_texts.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Callable
 
 
-class MainPanelTexts(Enum):
+class RootPanelTexts(Enum):
     """Texts for the main knowledge panel"""
 
     WELFARE_FOOTPRINT_INTRO = (

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -26,7 +26,7 @@ async def test_get_off_knowledge_panel(async_client: AsyncClient, sample_product
     # Test response has the expected structure
     response_data = response.json()
     assert "panels" in response_data
-    assert "main" in response_data["panels"]
+    assert "root" in response_data["panels"]
     assert "physical_pain" in response_data["panels"]
     assert "psychological_pain" in response_data["panels"]
     assert "intensities_definitions" in response_data["panels"]

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -259,14 +259,14 @@ def test_knowledge_panel_generator(
     # Create generator and test individual methods
     generator = KnowledgePanelGenerator(pain_report, translator)
 
-    # Test main panel
-    main_panel = generator._create_main_panel(["intensities_definitions", "physical_pain", "psychological_pain"])
-    assert main_panel.level == "info"
-    assert main_panel.title_element.title == "Welfare footprint"
-    assert len(main_panel.elements) > 3
+    # Test root panel
+    root_panel = generator._create_root_panel(["intensities_definitions", "physical_pain", "psychological_pain"])
+    assert root_panel.level == "info"
+    assert root_panel.title_element.title == "Welfare footprint"
+    assert len(root_panel.elements) > 3
     assert not any(
         el.text_element is not None and "missing" in el.text_element.html.lower()
-        for el in main_panel.elements
+        for el in root_panel.elements
         if el.element_type == "text"
     )
 
@@ -311,22 +311,22 @@ def test_knowledge_panel_generator_missing_quantity(pain_report_missing_quantity
     # Create generator and test individual methods
     generator = KnowledgePanelGenerator(pain_report_missing_quantity, translator)
 
-    # Test main panel
-    main_panel = generator._create_main_panel([])
-    assert main_panel.level == "info"
-    assert main_panel.title_element.title == "Welfare footprint"
+    # Test root panel
+    root_panel = generator._create_root_panel([])
+    assert root_panel.level == "info"
+    assert root_panel.title_element.title == "Welfare footprint"
 
-    # Test main panel elements as intro, uniqueness and missing data
-    assert len(main_panel.elements) > 3
+    # Test root panel elements as intro, uniqueness and missing data
+    assert len(root_panel.elements) > 3
     assert any(
         el.text_element is not None and "missing" in el.text_element.html.lower()
-        for el in main_panel.elements
+        for el in root_panel.elements
         if el.element_type == "text"
     )
 
     # Test complete response
     response = generator.get_response()
-    assert list(response.panels.keys()) == ["main"]
+    assert list(response.panels.keys()) == ["root"]
 
 
 @pytest.mark.parametrize(
@@ -342,7 +342,7 @@ def test_get_knowledge_panel_response(pain_report):
     response = get_knowledge_panel_response(pain_report, translator)
 
     # Verify response structure
-    assert "main" in response.panels
+    assert "root" in response.panels
     assert "physical_pain" in response.panels
     assert "psychological_pain" in response.panels
     assert "intensities_definitions" in response.panels
@@ -354,15 +354,15 @@ def test_get_knowledge_panel_response(pain_report):
 
 
 def test_get_knowledge_panel_response_missing_quantity(pain_report_missing_quantity: PainReport):
-    """Test that only main panel is generated when quantity is missing"""
+    """Test that only root panel is generated when quantity is missing"""
     translator = I18N().get_translator(locale="en")
 
     response = get_knowledge_panel_response(pain_report_missing_quantity, translator)
 
-    # On attend uniquement "main" dans les panels
-    assert list(response.panels.keys()) == ["main"]
-    assert hasattr(response.panels["main"], "elements")
-    assert hasattr(response.panels["main"], "title_element")
+    # On attend uniquement "root" dans les panels
+    assert list(response.panels.keys()) == ["root"]
+    assert hasattr(response.panels["root"], "elements")
+    assert hasattr(response.panels["root"], "title_element")
 
 
 @pytest.mark.parametrize(

--- a/frontend/app/[locale]/off/page.tsx
+++ b/frontend/app/[locale]/off/page.tsx
@@ -355,8 +355,8 @@ export default function KnowledgePanel() {
 
       {knowledgePanelData && !isLoading && (
         <div className="space-y-4">
-          {knowledgePanelData.panels.main &&
-            renderPanel('main', knowledgePanelData.panels.main, knowledgePanelData.panels)}
+          {knowledgePanelData.panels.root &&
+            renderPanel('root', knowledgePanelData.panels.root, knowledgePanelData.panels)}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

Openfoodfacts knowledge panel format requires root panel instead of main panel
Changed that in knowledge_panel generator and in tests
Adapted the frontend test page

Closes #220 