### PR TITLE
lock python version as 3.13

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ name = "suffering-footprint"
 version = "0.1.0"
 description = "Suffering Footprint API"
 authors = [{ name = "DataForGood" }]
-requires-python = "~=3.13"
+requires-python = "==3.13.*"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.13, <4"
+requires-python = "==3.13.*"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
## Description

New 3.14 python version causes dependencies probems with pydantic
Simply lock python version as 3.13 for now