### PR TITLE
fix/update enums for product type detection

### DIFF
--- a/backend/app/enums/open_food_facts/product_type_enums.py
+++ b/backend/app/enums/open_food_facts/product_type_enums.py
@@ -3,15 +3,28 @@ import unicodedata
 
 
 class ProductTypePatternRepository:
+    """
+    Repository of patterns for product type classification :
+     - egg detection
+     - fresh eggs detection
+     - chicken eggs detection
+    Used by the product type calculator
+    """
+
+    # categories tags that together indicate that the product is a fresh chicken egg
     FRESH_CHICKEN_EGG_TAGS = {
         "en:fresh-eggs",
         "en:chicken-eggs",
     }
 
+    # Terms that indicate that the egg product is fresh
     FRESH_EGG_TERMS = {"fresh", "frais", "freschi", "fresco"}
 
+    # Terms that indicate that the egg product is a chicken egg
     CHICKEN_EGG_TERMS = {"poule", "chicken", "hen", "gallina", "pollo"}
 
+    # Categories tags that are to be excluded because they
+    # indicate that the product is not fresh chicken eggs
     EXCLUDED_CATEGORY_TAGS = {
         "en:egg-yolk",
         "en:boiled-eggs",
@@ -40,8 +53,16 @@ class ProductTypePatternRepository:
         "en:cereals-and-potatoes",
         "fr:ovo-produits",
         "en:desserts",
+        "en:breads",
+        "en:fish-eggs",
+        "en:free-range-duck-eggs",
+        "en:raw-quail-eggs",
+        "en:savoury-eggs",
+        "en:streamed-eggs",
     }
 
+    # Words that are to be excluded if found in product names because
+    # they indicate that the product is not fresh chicken eggs
     EXCLUDED_WORDS = {
         "a la russe",
         "acidule?",
@@ -49,7 +70,6 @@ class ProductTypePatternRepository:
         "angelina",
         "assaisonnement",
         "assortis?",
-        "aux oeufs",
         "avec",
         "bacon",
         "baguette",
@@ -198,7 +218,7 @@ class ProductTypePatternRepository:
         "muges",
         "naproxene",
         "neiges?",
-        "nids?",
+        "nids",
         "noir",
         "noisettes?",
         "noodles?",
@@ -215,7 +235,7 @@ class ProductTypePatternRepository:
         "papillons",
         "pastes?",
         "pasteurise??",
-        "pastas?",
+        "pastas",
         "patissier",
         "pates?",
         "pate",
@@ -230,7 +250,6 @@ class ProductTypePatternRepository:
         "pomme",
         "poached",
         "poisson",
-        "poulet",
         "poussin",
         "prednisolone",
         "preema",
@@ -249,7 +268,6 @@ class ProductTypePatternRepository:
         "riz",
         "rocket",
         "rolls?",
-        "rouge",
         "rubans?",
         "rustic",
         "saumons?",
@@ -300,6 +318,7 @@ class ProductTypePatternRepository:
         "yolk",
     }
 
+    # regex construction from excluded words list
     EXCLUDED_PATTERNS = re.compile(
         r"\b(" + r"|".join([term.replace(" ", r"\s+") for term in EXCLUDED_WORDS]) + r")\b", re.VERBOSE
     )

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -480,9 +480,17 @@ laying_hen;barn;physical;hurtful;small;12.5
     )
 
 
-def test_get_product_type_fresh_chicken_egg(fresh_chicken_eggs_product: ProductData):
+@pytest.mark.parametrize(
+    "product_fixture",
+    [
+        ("fresh_chicken_eggs_product"),
+        ("label_rouge_eggs"),
+    ],
+)
+def test_get_product_type_fresh_chicken_egg(product_fixture: ProductData, request):
     """Test that a fresh chicken egg is correctly identified as a laying hen product"""
-    product_type = get_product_type(fresh_chicken_eggs_product)
+    product = request.getfixturevalue(product_fixture)
+    product_type = get_product_type(product)
     assert product_type == ProductType(is_mixed=False, animal_types={AnimalType.LAYING_HEN})
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -270,6 +270,15 @@ def fresh_chicken_eggs_product():
 
 
 @pytest.fixture
+def label_rouge_eggs():
+    return ProductData(
+        product_name="6 oeufs Label rouge",
+        categories_tags=["en:eggs"],
+        quantity="",
+    )
+
+
+@pytest.fixture
 def liquid_eggs_product():
     return ProductData(
         product_name="Liquid Eggs",


### PR DESCRIPTION
## Description

- removed some patterns that can sometimes be found in products names (ex : 'nid' in "le nid lorrain", 'rouge' in "label rouge"), previsously used to consider a product is not a fresh egg
- added a test to make sure label rouge products are not excluded from eggs by product type calculator