### PR TITLE
Fix animated cards

### DIFF
--- a/frontend/app/[locale]/methodology/_components/animated-afflictions.tsx
+++ b/frontend/app/[locale]/methodology/_components/animated-afflictions.tsx
@@ -91,7 +91,7 @@ export function AnimatedCard({ afflictions, index, offset, cascade }: AnimatedCa
           className={`absolute left-0 top-0 w-full z-1
             transition-transform duration-500
             -translate-x-full
-            ${entering ? 'translate-x-full' : 'translate-x-0'}
+            ${entering ? '-translate-x-full' : 'translate-x-0'}
 
           `}
           style={{ pointerEvents: 'none' }}

--- a/frontend/app/[locale]/methodology/_components/animated-afflictions.tsx
+++ b/frontend/app/[locale]/methodology/_components/animated-afflictions.tsx
@@ -31,14 +31,17 @@ export function AnimatedAfflictionsGroup({ afflictions, delay = 4000, cascade = 
 
   return (
     <div>
-      {[0, 1, 2].map((offset, idx, arr) => (
-        <div key={offset}>
-          <AnimatedCard afflictions={afflictions} index={index} offset={offset} cascade={cascade} />
-          {idx < arr.length - 0 && (
-            <div className="bg-violet rounded-[5px] p-2 my-4 text-center text-3xl font-extrabold w-full">+</div>
-          )}
-        </div>
-      ))}
+      {[0, 1, 2].map((_, idx) => {
+        const offset = Math.floor((idx * afflictions.length) / 3);
+        return (
+          <div key={offset}>
+            <AnimatedCard afflictions={afflictions} index={index} offset={offset} cascade={cascade} />
+            {idx < 2 && (
+              <div className="bg-violet rounded-[5px] p-2 my-4 text-center text-3xl font-extrabold w-full">+</div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fix the animated cards on methodology page.

There was two issues : 
- the 3 animated cards were displaying the same data
- the exiting cards was exiting on the same side as the new card was entering

## Code changes

- new offset calculation for a different starting point in the array of afflictions to display
- small css change to fix the side of the card exiting

## How to test

cd frontend
npm run dev
