### PR TITLE
feat(frontend-title): remove page name title on main page

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -1,4 +1,3 @@
-
 import ResultsSection from '@/app/[locale]/home/_sections/results-section';
 import GoFurtherSection from '@/app/[locale]/ui/_sections/go-further-section';
 import ProgressSection from './home/_sections/progress-section';
@@ -6,9 +5,10 @@ import HeroPressSection from './home/_sections/hero-press-section';
 import PromiseKeptSection from './home/_sections/promise-kept-section';
 
 import { Metadata } from 'next';
+
 export const metadata: Metadata = {
-  title: 'Accueil',
-  description: "L’heure des comptes révèle si les supermarchés ont tenu leur promesse de ne plus vendre d’œufs de poules en cage, en s’appuyant sur une enquête d’Anima.",
+  description:
+    'L’heure des comptes révèle si les supermarchés ont tenu leur promesse de ne plus vendre d’œufs de poules en cage, en s’appuyant sur une enquête d’Anima.',
   keywords: [
     'engagement supermarchés œufs cage',
     'promesse 2026',
@@ -20,13 +20,15 @@ export const metadata: Metadata = {
     'promesse tenue supermarchés',
   ],
   openGraph: {
-    title: 'Promesse tenue ? C\'est l\'heure des comptes - Anima',
-    description: "L’heure des comptes révèle si les supermarchés ont tenu leur promesse de ne plus vendre d’œufs de poules en cage, en s’appuyant sur une enquête d’Anima.",
+    title: "Promesse tenue ? C'est l'heure des comptes - Anima",
+    description:
+      'L’heure des comptes révèle si les supermarchés ont tenu leur promesse de ne plus vendre d’œufs de poules en cage, en s’appuyant sur une enquête d’Anima.',
     images: ['/og-image.png'],
   },
   twitter: {
-    title: 'Promesse tenue ? C\'est l\'heure des comptes - Anima',
-   description: "L’heure des comptes révèle si les supermarchés ont tenu leur promesse de ne plus vendre d’œufs de poules en cage, en s’appuyant sur une enquête d’Anima.",
+    title: "Promesse tenue ? C'est l'heure des comptes - Anima",
+    description:
+      'L’heure des comptes révèle si les supermarchés ont tenu leur promesse de ne plus vendre d’œufs de poules en cage, en s’appuyant sur une enquête d’Anima.',
     images: ['/og-image.png'],
   },
   alternates: {


### PR DESCRIPTION
## Description

<img width="992" height="44" alt="image" src="https://github.com/user-attachments/assets/3e1c46ab-fec8-4df8-9d17-29a84b66fb29" />


## Code changes

Remove `title` on main page so the metadata will use default + linter

## How to test

<!-- Describe how to test (if relevant) -->
