### PR TITLE
Create a global client for OFF API

### DIFF
--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -1,11 +1,11 @@
 import logging
 from typing import Callable, List
 
-import httpx
 from pydantic import HttpUrl, ValidationError
 
 from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import ResourceNotFoundException
+from app.config.http_client import get_with_retry
 from app.enums.open_food_facts.enums import AnimalType, PainType
 from app.enums.open_food_facts.panel_texts import (
     AnimalInfoTexts,
@@ -52,10 +52,9 @@ async def get_data_from_off_v3(barcode: str, locale: str) -> ProductData:
     product_name_with_locale = f"product_name_{locale}"
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url)
-            response.raise_for_status()  # Raise exception for 4XX/5XX responses
-            json_response = response.json()
+        response = await get_with_retry(url)
+        response.raise_for_status()  # Raise exception for 4XX/5XX responses
+        json_response = response.json()
     except Exception as e:
         logger.warning(f"Can't get product data from OFF API: {barcode}")
         raise ResourceNotFoundException(f"Can't get product data from OFF API: {barcode}") from e
@@ -110,10 +109,9 @@ async def get_data_from_off_search_a_licious(barcode: str, locale: str) -> Produ
     params = {"q": f"code:{barcode}", "fields": ",".join(tags)}
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, params=params)
-            response.raise_for_status()  # Raise exception for 4XX/5XX responses
-            json_response = response.json()
+        response = await get_with_retry(url, params=params)
+        response.raise_for_status()  # Raise exception for 4XX/5XX responses
+        json_response = response.json()
     except Exception as e:
         logger.warning(f"Can't get product data from OFF API: {barcode}")
         raise ResourceNotFoundException(f"Can't get product data from OFF API: {barcode}") from e

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -7,6 +7,8 @@ from pydantic import ValidationError
 from app.business.open_food_facts.egg_knowledge_panel_generator import EggKnowledgePanelGenerator
 from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import EggButNotFreshEgg, ResourceNotFoundException
+from app.config.http_client import get_with_retry
+
 from app.enums.open_food_facts.enums import AnimalType
 from app.schemas.open_food_facts.external import ProductData, ProductResponse, ProductResponseSearchALicious
 from app.schemas.open_food_facts.internal import (
@@ -36,15 +38,9 @@ async def get_data_from_off_v3(barcode: str, locale: str) -> ProductData:
     product_name_with_locale = f"product_name_{locale}"
 
     try:
-        async with httpx.AsyncClient(
-            headers={"User-Agent": "my-app/1.0"},
-            follow_redirects=True,
-            timeout=20.0,
-        ) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            json_response = response.json()
-
+        response = await get_with_retry(url)
+        response.raise_for_status()  # Raise exception for 4XX/5XX responses
+        json_response = response.json()
     except Exception as e:
         logger.warning(f"OFF API error: {type(e).__name__}: {e}")
         raise ResourceNotFoundException(f"Can't get product data from OFF API: {barcode}") from e
@@ -99,10 +95,9 @@ async def get_data_from_off_search_a_licious(barcode: str, locale: str) -> Produ
     params = {"q": f"code:{barcode}", "fields": ",".join(tags)}
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, params=params)
-            response.raise_for_status()  # Raise exception for 4XX/5XX responses
-            json_response = response.json()
+        response = await get_with_retry(url, params=params)
+        response.raise_for_status()  # Raise exception for 4XX/5XX responses
+        json_response = response.json()
     except Exception as e:
         logger.warning(f"Can't get product data from OFF search-a-licious API: {barcode}")
         raise ResourceNotFoundException(f"Can't get product data from OFF API: {barcode}") from e

--- a/backend/app/config/cache.py
+++ b/backend/app/config/cache.py
@@ -25,7 +25,7 @@ class SimpleCache:
         self._cache: dict[str, CacheEntry] = {}
         self._lock = Lock()
 
-    def _generate_key(self, *args, **kwargs) -> str:
+    def _generate_key(self, *args: Any, **kwargs: Any) -> str:
         """Generate a cache key from arguments."""
         key_data = {"args": args, "kwargs": kwargs}
         return json.dumps(key_data, sort_keys=True, default=str)
@@ -43,10 +43,11 @@ class SimpleCache:
 
             return entry.data
 
-    def set(self, key: str, value: Any, ttl_seconds: int = 3600) -> None:
+    def set(self, key: str, value: Any, ttl_seconds: int = 3600) -> Optional[Any]:
         """Set a value in cache with TTL."""
         with self._lock:
             self._cache[key] = CacheEntry(data=value, timestamp=time.time(), ttl_seconds=ttl_seconds)
+        return None
 
     def delete(self, key: str) -> bool:
         """Delete a key from cache. Returns True if key existed."""

--- a/backend/app/config/cache.py
+++ b/backend/app/config/cache.py
@@ -21,7 +21,7 @@ class SimpleCache:
     Thread-safe for concurrent access.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cache: dict[str, CacheEntry] = {}
         self._lock = Lock()
 
@@ -29,6 +29,8 @@ class SimpleCache:
         """Generate a cache key from arguments."""
         key_data = {"args": args, "kwargs": kwargs}
         return json.dumps(key_data, sort_keys=True, default=str)
+
+        return None
 
     def get(self, key: str) -> Optional[Any]:
         """Get a value from cache if it exists and is not expired."""

--- a/backend/app/config/cache.py
+++ b/backend/app/config/cache.py
@@ -25,12 +25,10 @@ class SimpleCache:
         self._cache: dict[str, CacheEntry] = {}
         self._lock = Lock()
 
-    def _generate_key(self, *args: Any, **kwargs: Any) -> str:
+    def _generate_key(self, *args, **kwargs) -> str:
         """Generate a cache key from arguments."""
         key_data = {"args": args, "kwargs": kwargs}
         return json.dumps(key_data, sort_keys=True, default=str)
-
-        return None
 
     def get(self, key: str) -> Optional[Any]:
         """Get a value from cache if it exists and is not expired."""
@@ -45,11 +43,10 @@ class SimpleCache:
 
             return entry.data
 
-    def set(self, key: str, value: Any, ttl_seconds: int = 3600) -> Optional[Any]:
+    def set(self, key: str, value: Any, ttl_seconds: int = 3600) -> None:
         """Set a value in cache with TTL."""
         with self._lock:
             self._cache[key] = CacheEntry(data=value, timestamp=time.time(), ttl_seconds=ttl_seconds)
-        return None
 
     def delete(self, key: str) -> bool:
         """Delete a key from cache. Returns True if key existed."""

--- a/backend/app/config/http_client.py
+++ b/backend/app/config/http_client.py
@@ -1,0 +1,53 @@
+import asyncio
+import logging
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger("app")
+
+client = httpx.AsyncClient(
+    headers={"User-Agent": "my-app/1.0"},
+    follow_redirects=True,
+    timeout=httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0),
+    limits=httpx.Limits(
+        max_connections=20,
+        max_keepalive_connections=10,
+    ),
+)
+
+_semaphore = asyncio.Semaphore(3)
+
+
+async def get(url: str, **kwargs) -> httpx.Response:
+    async with _semaphore:
+        response = await client.get(url, **kwargs)
+        response.raise_for_status()
+        return response
+
+
+async def get_with_retry(
+    url: str,
+    retries: int = 3,
+    base_delay: float = 1.0,
+    **kwargs,
+) -> httpx.Response:
+    last_exception: Optional[Exception] = None
+
+    for attempt in range(retries):
+        try:
+            return await get(url, **kwargs)
+
+        except (httpx.HTTPError, httpx.TimeoutException) as e:
+            last_exception = e
+            logger.warning(f"HTTP error on attempt {attempt + 1}/{retries} for {url}: {type(e).__name__}")
+
+            if attempt < retries - 1:
+                await asyncio.sleep(base_delay * (2**attempt))
+
+    if last_exception is not None:
+        raise last_exception
+
+
+async def close_http_client():
+    await client.aclose()

--- a/backend/app/config/http_client.py
+++ b/backend/app/config/http_client.py
@@ -45,8 +45,7 @@ async def get_with_retry(
             if attempt < retries - 1:
                 await asyncio.sleep(base_delay * (2**attempt))
 
-    if last_exception is not None:
-        raise last_exception
+    raise last_exception or RuntimeError("Retry failed without exception")
 
 
 async def close_http_client():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.open_food_facts.routes import router as off_router
+from app.config.http_client import close_http_client
 from app.config.logging import setup_logging
 from app.config.middlewares import (
     GlobalExceptionMiddleware,
@@ -35,6 +36,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 # Health check endpoint for Docker healthcheck
 @app.get("/health", tags=["Health"])
 async def health_check():
@@ -44,6 +46,12 @@ async def health_check():
 
 # Include API routes
 app.include_router(off_router, prefix="/off/v1", tags=["Open Food Facts"])
+
+
+# close connections
+@app.on_event("shutdown")
+async def shutdown_event():
+    await close_http_client()
 
 
 # Go in the app folder and run the server with: uvicorn main:app --reload

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -16,13 +16,14 @@ async def test_get_off_knowledge_panel(async_client: AsyncClient, sample_product
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = Mock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        # Get the instance returned by the async context
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
+
         response = await async_client.get("/off/v1/knowledge-panel/1")
 
     assert response.status_code == 200
+
     # Test response has the expected structure
     response_data = response.json()
     assert "panels" in response_data
@@ -52,25 +53,24 @@ async def test_knowledge_panel_cache_miss_then_hit(async_client: AsyncClient, sa
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = AsyncMock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        # Get the instance returned by the async context
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
 
         # First request - should be a cache miss
         response1 = await async_client.get("/off/v1/knowledge-panel/123456789")
         assert response1.status_code == 200
 
         # Verify the external API was called (cache miss)
-        assert instance.get.called
-        call_count_after_first_request = instance.get.call_count
+        assert mock_get.called
+        call_count_after_first_request = mock_get.call_count
 
         # Second request with same barcode - should be a cache hit
         response2 = await async_client.get("/off/v1/knowledge-panel/123456789")
         assert response2.status_code == 200
 
         # Verify the external API was NOT called again (cache hit)
-        assert instance.get.call_count == call_count_after_first_request
+        assert mock_get.call_count == call_count_after_first_request
 
         # Verify responses are identical
         assert response1.json() == response2.json()
@@ -87,19 +87,19 @@ async def test_knowledge_panel_cache_different_locales(async_client: AsyncClient
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = AsyncMock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
 
         # Request with English locale
         response_en = await async_client.get("/off/v1/knowledge-panel/123456789", headers={"Accept-Language": "en"})
         assert response_en.status_code == 200
-        calls_after_en = instance.get.call_count
+        calls_after_en = mock_get.call_count
 
         # Request with French locale (same barcode) - should trigger new API call
         response_fr = await async_client.get("/off/v1/knowledge-panel/123456789", headers={"Accept-Language": "fr"})
         assert response_fr.status_code == 200
-        calls_after_fr = instance.get.call_count
+        calls_after_fr = mock_get.call_count
 
         # Verify both requests triggered API calls (different cache entries)
         assert calls_after_fr > calls_after_en
@@ -111,7 +111,7 @@ async def test_knowledge_panel_cache_different_locales(async_client: AsyncClient
         assert response_en_cached.status_code == 200
 
         # Verify no additional API call was made (cache hit)
-        assert instance.get.call_count == calls_after_fr
+        assert mock_get.call_count == calls_after_fr
 
 
 @pytest.mark.asyncio
@@ -125,19 +125,19 @@ async def test_knowledge_panel_cache_different_barcodes(async_client: AsyncClien
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = AsyncMock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
 
         # First barcode
         response1 = await async_client.get("/off/v1/knowledge-panel/111111111")
         assert response1.status_code == 200
-        calls_after_first = instance.get.call_count
+        calls_after_first = mock_get.call_count
 
         # Different barcode - should trigger new API call
         response2 = await async_client.get("/off/v1/knowledge-panel/222222222")
         assert response2.status_code == 200
-        calls_after_second = instance.get.call_count
+        calls_after_second = mock_get.call_count
 
         # Verify both requests triggered API calls (different cache entries)
         assert calls_after_second > calls_after_first
@@ -147,4 +147,4 @@ async def test_knowledge_panel_cache_different_barcodes(async_client: AsyncClien
         assert response1_cached.status_code == 200
 
         # Verify no additional API call was made (cache hit)
-        assert instance.get.call_count == calls_after_second
+        assert mock_get.call_count == calls_after_second

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -16,13 +16,14 @@ async def test_get_off_knowledge_panel(async_client: AsyncClient, sample_product
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = Mock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        # Get the instance returned by the async context
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
+
         response = await async_client.get("/off/v1/knowledge-panel/1")
 
     assert response.status_code == 200
+
     # Test response has the expected structure
     response_data = response.json()
     assert "panels" in response_data
@@ -50,25 +51,24 @@ async def test_knowledge_panel_cache_miss_then_hit(async_client: AsyncClient, sa
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = AsyncMock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        # Get the instance returned by the async context
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
 
         # First request - should be a cache miss
         response1 = await async_client.get("/off/v1/knowledge-panel/123456789")
         assert response1.status_code == 200
 
         # Verify the external API was called (cache miss)
-        assert instance.get.called
-        call_count_after_first_request = instance.get.call_count
+        assert mock_get.called
+        call_count_after_first_request = mock_get.call_count
 
         # Second request with same barcode - should be a cache hit
         response2 = await async_client.get("/off/v1/knowledge-panel/123456789")
         assert response2.status_code == 200
 
         # Verify the external API was NOT called again (cache hit)
-        assert instance.get.call_count == call_count_after_first_request
+        assert mock_get.call_count == call_count_after_first_request
 
         # Verify responses are identical
         assert response1.json() == response2.json()
@@ -85,19 +85,19 @@ async def test_knowledge_panel_cache_different_locales(async_client: AsyncClient
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = AsyncMock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
 
         # Request with English locale
         response_en = await async_client.get("/off/v1/knowledge-panel/123456789", headers={"Accept-Language": "en"})
         assert response_en.status_code == 200
-        calls_after_en = instance.get.call_count
+        calls_after_en = mock_get.call_count
 
         # Request with French locale (same barcode) - should trigger new API call
         response_fr = await async_client.get("/off/v1/knowledge-panel/123456789", headers={"Accept-Language": "fr"})
         assert response_fr.status_code == 200
-        calls_after_fr = instance.get.call_count
+        calls_after_fr = mock_get.call_count
 
         # Verify both requests triggered API calls (different cache entries)
         assert calls_after_fr > calls_after_en
@@ -109,7 +109,7 @@ async def test_knowledge_panel_cache_different_locales(async_client: AsyncClient
         assert response_en_cached.status_code == 200
 
         # Verify no additional API call was made (cache hit)
-        assert instance.get.call_count == calls_after_fr
+        assert mock_get.call_count == calls_after_fr
 
 
 @pytest.mark.asyncio
@@ -123,19 +123,19 @@ async def test_knowledge_panel_cache_different_barcodes(async_client: AsyncClien
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = AsyncMock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch("app.business.open_food_facts.knowledge_panel.get_with_retry", new_callable=AsyncMock) as mock_get:
+        # Mock external HTTP call
+        mock_get.return_value = mock_response
 
         # First barcode
         response1 = await async_client.get("/off/v1/knowledge-panel/111111111")
         assert response1.status_code == 200
-        calls_after_first = instance.get.call_count
+        calls_after_first = mock_get.call_count
 
         # Different barcode - should trigger new API call
         response2 = await async_client.get("/off/v1/knowledge-panel/222222222")
         assert response2.status_code == 200
-        calls_after_second = instance.get.call_count
+        calls_after_second = mock_get.call_count
 
         # Verify both requests triggered API calls (different cache entries)
         assert calls_after_second > calls_after_first
@@ -145,4 +145,4 @@ async def test_knowledge_panel_cache_different_barcodes(async_client: AsyncClien
         assert response1_cached.status_code == 200
 
         # Verify no additional API call was made (cache hit)
-        assert instance.get.call_count == calls_after_second
+        assert mock_get.call_count == calls_after_second

--- a/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
+++ b/backend/tests/app/business/open_food_facts/test_knowledge_panel.py
@@ -117,7 +117,7 @@ async def test_get_data_from_off_http_call_exception(get_data_from_off_function:
     """Test when the OFF API returns an HTTP error"""
     barcode = "111111111"
 
-    with patch("httpx.AsyncClient.__aenter__", side_effect=httpx.ReadTimeout("Network error")):
+    with patch("app.config.http_client.client.get", side_effect=httpx.ReadTimeout("Network error")):
         with pytest.raises(ResourceNotFoundException, match=f"Can't get product data from OFF API: {barcode}"):
             await get_data_from_off_function(barcode, locale="en")
 


### PR DESCRIPTION
## Description

Create a global client for OFF API to avoid "too many connections" answer from OFF

## Code changes

- create `http_client.py`
- adapt `knowledge_panel.py`
- close connection in `main.py`
- update tests

## How to test

Checks logs when requesting many products in test page