### PR TITLE
Feat/painreportlist endpoint

### DIFF
--- a/backend/app/api/open_food_facts/routes.py
+++ b/backend/app/api/open_food_facts/routes.py
@@ -1,11 +1,11 @@
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Query, Response
 from starlette.requests import Request
 
-from app.business.open_food_facts.knowledge_panel import get_knowledge_panel_response, get_pain_reports
+from app.business.open_food_facts.knowledge_panel import get_knowledge_panel_response, get_pain_reports, get_pain_reports_batch
 from app.config.cache import knowledge_panel_cache
 from app.config.exceptions import ExternalServiceException, ResourceNotFoundException
 from app.config.logging import setup_logging
-from app.schemas.open_food_facts.internal import KnowledgePanelResponse
+from app.schemas.open_food_facts.internal import KnowledgePanelBatchResponse, KnowledgePanelResponse
 
 router = APIRouter()
 logger = setup_logging()
@@ -19,7 +19,7 @@ logger = setup_logging()
 )
 async def knowledge_panel(request: Request, barcode: str):
     """
-    API endpoint to return knowledge panel details.
+    API endpoint to return knowledge panel details for a single product.
     Handles both GET and HEAD methods.
 
     Args:
@@ -61,3 +61,60 @@ async def knowledge_panel(request: Request, barcode: str):
         return Response(status_code=200)
 
     return response
+
+
+@router.get(
+    "/knowledge-panels",
+    response_model=KnowledgePanelBatchResponse,
+    response_model_exclude_none=True,
+)
+async def knowledge_panels_batch(
+    request: Request,
+    barcodes: str = Query(..., description="Comma-separated list of product barcodes"),
+):
+    """
+    API endpoint to return knowledge panels for multiple products in a single call.
+    Processes all barcodes in parallel. Failures on individual barcodes are reported
+    in the 'errors' field without affecting the other results.
+
+    Args:
+        request: The request object.
+        barcodes: Comma-separated barcodes, e.g. "3017620422003,3228857000166"
+
+    Returns:
+        KnowledgePanelBatchResponse with 'panels' (successes) and 'errors' (failures)
+    """
+    locale = request.state.locale
+    barcode_list = [b.strip() for b in barcodes.split(",") if b.strip()]
+
+    logger.info(f"Getting knowledge panels for {len(barcode_list)} products (locale: {locale})")
+
+    # Separate barcodes into cached and to-fetch
+    panels: dict = {}
+    errors: dict = {}
+    barcodes_to_fetch = []
+
+    for barcode in barcode_list:
+        cache_key = f"knowledge_panel:{barcode}:{locale}"
+        cached = knowledge_panel_cache.get(cache_key)
+        if cached is not None:
+            logger.info(f"Returning cached knowledge panel for product {barcode} (locale: {locale})")
+            panels[barcode] = cached
+        else:
+            barcodes_to_fetch.append(barcode)
+
+    # Fetch remaining barcodes in parallel
+    if barcodes_to_fetch:
+        pain_reports = await get_pain_reports_batch(barcodes=barcodes_to_fetch, locale=locale)
+
+        for barcode, result in pain_reports.items():
+            if isinstance(result, BaseException):
+                logger.warning(f"Failed to get pain report for product {barcode}: {result}")
+                errors[barcode] = str(result)
+            else:
+                response = get_knowledge_panel_response(pain_report=result, translator=request.state.translator)
+                cache_key = f"knowledge_panel:{barcode}:{locale}"
+                knowledge_panel_cache.set(cache_key, response, ttl_seconds=86400)
+                panels[barcode] = response
+
+    return KnowledgePanelBatchResponse(panels=panels, errors=errors)

--- a/backend/app/api/open_food_facts/routes.py
+++ b/backend/app/api/open_food_facts/routes.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter, Query, Response
 from starlette.requests import Request
 
-from app.business.open_food_facts.knowledge_panel import get_knowledge_panel_response, get_pain_reports, get_pain_reports_batch
+from app.business.open_food_facts.knowledge_panel import (
+    get_knowledge_panel_response,
+    get_pain_reports,
+    get_pain_reports_batch,
+)
 from app.config.cache import knowledge_panel_cache
 from app.config.exceptions import ExternalServiceException, ResourceNotFoundException
 from app.config.logging import setup_logging
@@ -110,7 +114,9 @@ async def knowledge_panels_batch(
                 logger.warning(f"Failed to get pain report for product {barcode}: {result}")
                 errors[barcode] = str(result)
             else:
-                response = get_knowledge_panel_response(pain_report=result, translator=request.state.translator)
+                response = get_knowledge_panel_response(
+                    pain_reports=result, translator=request.state.translator, locale=locale
+                )
                 cache_key = f"knowledge_panel:{barcode}:{locale}"
                 knowledge_panel_cache.set(cache_key, response, ttl_seconds=86400)
                 panels[barcode] = response

--- a/backend/app/api/open_food_facts/routes.py
+++ b/backend/app/api/open_food_facts/routes.py
@@ -64,32 +64,31 @@ async def knowledge_panel(request: Request, barcode: str):
 
 
 @router.get(
-    "/knowledge-panels",
+    "/knowledge-panel/",
     response_model=KnowledgePanelBatchResponse,
     response_model_exclude_none=True,
 )
 async def knowledge_panels_batch(
     request: Request,
-    barcodes: str = Query(..., description="Comma-separated list of product barcodes"),
+    code: str = Query(..., description="Comma-separated list of product barcodes"),
 ):
     """
-    API endpoint to return knowledge panels for multiple products in a single call.
+    API endpoint to return knowledge panels for one or several products in a single call.
     Processes all barcodes in parallel. Failures on individual barcodes are reported
     in the 'errors' field without affecting the other results.
 
     Args:
         request: The request object.
-        barcodes: Comma-separated barcodes, e.g. "3017620422003,3228857000166"
+        code: Comma-separated barcodes, e.g. "3017620422003" or "3017620422003,3228857000166"
 
     Returns:
         KnowledgePanelBatchResponse with 'panels' (successes) and 'errors' (failures)
     """
     locale = request.state.locale
-    barcode_list = [b.strip() for b in barcodes.split(",") if b.strip()]
+    barcode_list = [b.strip() for b in code.split(",") if b.strip()]
 
     logger.info(f"Getting knowledge panels for {len(barcode_list)} products (locale: {locale})")
 
-    # Separate barcodes into cached and to-fetch
     panels: dict = {}
     errors: dict = {}
     barcodes_to_fetch = []
@@ -103,7 +102,6 @@ async def knowledge_panels_batch(
         else:
             barcodes_to_fetch.append(barcode)
 
-    # Fetch remaining barcodes in parallel
     if barcodes_to_fetch:
         pain_reports = await get_pain_reports_batch(barcodes=barcodes_to_fetch, locale=locale)
 

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -2,14 +2,12 @@ import asyncio
 import logging
 from typing import Callable, List
 
-import httpx
 from pydantic import ValidationError
 
 from app.business.open_food_facts.egg_knowledge_panel_generator import EggKnowledgePanelGenerator
 from app.business.open_food_facts.pain_report_calculator import PainReportCalculator
 from app.config.exceptions import EggButNotFreshEgg, ResourceNotFoundException
 from app.config.http_client import get_with_retry
-
 from app.enums.open_food_facts.enums import AnimalType
 from app.schemas.open_food_facts.external import ProductData, ProductResponse, ProductResponseSearchALicious
 from app.schemas.open_food_facts.internal import (
@@ -178,7 +176,7 @@ def get_generator(
     raise ResourceNotFoundException(f"Unsupported product type: {product_type}")
 
 
-async def get_pain_reports_batch(barcodes: list[str], locale: str) -> dict[str, PainReport | BaseException]:
+async def get_pain_reports_batch(barcodes: list[str], locale: str) -> dict[str, list[PainReport] | BaseException]:
     """
     Compute pain reports for multiple products in parallel.
 

--- a/backend/app/business/open_food_facts/knowledge_panel.py
+++ b/backend/app/business/open_food_facts/knowledge_panel.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Callable, List
 
@@ -175,6 +176,24 @@ def get_generator(
         )
 
     raise ResourceNotFoundException(f"Unsupported product type: {product_type}")
+
+
+async def get_pain_reports_batch(barcodes: list[str], locale: str) -> dict[str, PainReport | BaseException]:
+    """
+    Compute pain reports for multiple products in parallel.
+
+    Each barcode is processed independently — a failure on one does not affect the others.
+
+    Args:
+        barcodes: List of product barcodes
+        locale: alpha2 locale (fr, en...)
+
+    Returns:
+        A dict mapping each barcode to either a PainReport or an Exception
+    """
+    tasks = [get_pain_reports(barcode=barcode, locale=locale) for barcode in barcodes]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    return {barcode: result for barcode, result in zip(barcodes, results)}
 
 
 def get_knowledge_panel_response(

--- a/backend/app/schemas/open_food_facts/internal.py
+++ b/backend/app/schemas/open_food_facts/internal.py
@@ -91,3 +91,8 @@ class KnowledgePanelResponse(BaseModel):
 
     panels: Dict[str, Panel]
     product: ProductInfo
+
+
+class KnowledgePanelBatchResponse(BaseModel):
+    panels: Dict[str, KnowledgePanelResponse] = {}
+    errors: Dict[str, str] = {}

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -145,7 +145,7 @@ async def test_knowledge_panel_cache_different_barcodes(async_client: AsyncClien
         assert response1_cached.status_code == 200
 
         # Verify no additional API call was made (cache hit)
-        assert instance.get.call_count == calls_after_second
+        assert mock_get.call_count == calls_after_second
 
 
 @pytest.mark.asyncio
@@ -158,9 +158,11 @@ async def test_knowledge_panels_batch_single_barcode(async_client: AsyncClient, 
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = Mock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch(
+        "app.business.open_food_facts.knowledge_panel.get_with_retry",
+        new_callable=AsyncMock,
+    ) as mock_get:
+        mock_get.return_value = mock_response
         response = await async_client.get("/off/v1/knowledge-panel/?code=123456789")
 
     assert response.status_code == 200
@@ -181,9 +183,11 @@ async def test_knowledge_panels_batch_multiple_barcodes(async_client: AsyncClien
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = Mock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch(
+        "app.business.open_food_facts.knowledge_panel.get_with_retry",
+        new_callable=AsyncMock,
+    ) as mock_get:
+        mock_get.return_value = mock_response
         response = await async_client.get("/off/v1/knowledge-panel/?code=111111111,222222222,333333333")
 
     assert response.status_code == 200
@@ -220,9 +224,11 @@ async def test_knowledge_panels_batch_partial_failure(async_client: AsyncClient,
                 return resp
         return error_response
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.side_effect = mock_get
+    with patch(
+        "app.business.open_food_facts.knowledge_panel.get_with_retry",
+        new_callable=AsyncMock,
+    ) as mock_get_retry:
+        mock_get_retry.side_effect = mock_get
         response = await async_client.get("/off/v1/knowledge-panel/?code=111111111,999999999")
 
     assert response.status_code == 200
@@ -241,16 +247,18 @@ async def test_knowledge_panels_batch_uses_cache(async_client: AsyncClient, samp
     mock_response.json = MagicMock(return_value=mock_response_data)
     mock_response.raise_for_status = Mock(return_value=None)
 
-    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
-        instance = mock_http_client.return_value.__aenter__.return_value
-        instance.get.return_value = mock_response
+    with patch(
+        "app.business.open_food_facts.knowledge_panel.get_with_retry",
+        new_callable=AsyncMock,
+    ) as mock_get:
+        mock_get.return_value = mock_response
 
         # First call - cache miss for both
         response1 = await async_client.get("/off/v1/knowledge-panel/?code=111111111,222222222")
         assert response1.status_code == 200
-        calls_after_first = instance.get.call_count
+        calls_after_first = mock_get.call_count
 
         # Second call - cache hit for both, no new API calls expected
         response2 = await async_client.get("/off/v1/knowledge-panel/?code=111111111,222222222")
         assert response2.status_code == 200
-        assert instance.get.call_count == calls_after_first
+        assert mock_get.call_count == calls_after_first

--- a/backend/tests/app/api/open_food_facts/test_routes.py
+++ b/backend/tests/app/api/open_food_facts/test_routes.py
@@ -145,4 +145,112 @@ async def test_knowledge_panel_cache_different_barcodes(async_client: AsyncClien
         assert response1_cached.status_code == 200
 
         # Verify no additional API call was made (cache hit)
-        assert mock_get.call_count == calls_after_second
+        assert instance.get.call_count == calls_after_second
+
+
+@pytest.mark.asyncio
+async def test_knowledge_panels_batch_single_barcode(async_client: AsyncClient, sample_product_data: ProductData):
+    """Test the batch endpoint with a single barcode"""
+    knowledge_panel_cache.clear()
+
+    mock_response_data = {"product": sample_product_data}
+    mock_response = AsyncMock()
+    mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = Mock(return_value=None)
+
+    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
+        instance = mock_http_client.return_value.__aenter__.return_value
+        instance.get.return_value = mock_response
+        response = await async_client.get("/off/v1/knowledge-panel/?code=123456789")
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert "panels" in response_data
+    assert "errors" in response_data
+    assert "123456789" in response_data["panels"]
+    assert response_data["errors"] == {}
+
+
+@pytest.mark.asyncio
+async def test_knowledge_panels_batch_multiple_barcodes(async_client: AsyncClient, sample_product_data: ProductData):
+    """Test the batch endpoint with multiple barcodes"""
+    knowledge_panel_cache.clear()
+
+    mock_response_data = {"product": sample_product_data}
+    mock_response = AsyncMock()
+    mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = Mock(return_value=None)
+
+    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
+        instance = mock_http_client.return_value.__aenter__.return_value
+        instance.get.return_value = mock_response
+        response = await async_client.get("/off/v1/knowledge-panel/?code=111111111,222222222,333333333")
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data["panels"]) == 3
+    assert "111111111" in response_data["panels"]
+    assert "222222222" in response_data["panels"]
+    assert "333333333" in response_data["panels"]
+    assert response_data["errors"] == {}
+
+
+@pytest.mark.asyncio
+async def test_knowledge_panels_batch_partial_failure(async_client: AsyncClient, sample_product_data: ProductData):
+    """Test that a failure on one barcode does not affect the others"""
+    knowledge_panel_cache.clear()
+
+    success_response = AsyncMock()
+    success_response.json = MagicMock(return_value={"product": sample_product_data})
+    success_response.raise_for_status = Mock(return_value=None)
+
+    error_response = AsyncMock()
+    error_response.json = MagicMock(return_value={})  # No "product" key triggers ResourceNotFoundException
+    error_response.raise_for_status = Mock(return_value=None)
+
+    # Return success for first barcode, error for second
+    responses_by_barcode = {
+        "111111111": success_response,
+        "999999999": error_response,
+    }
+
+    async def mock_get(url, *args, **kwargs):
+        for barcode, resp in responses_by_barcode.items():
+            if barcode in url:
+                return resp
+        return error_response
+
+    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
+        instance = mock_http_client.return_value.__aenter__.return_value
+        instance.get.side_effect = mock_get
+        response = await async_client.get("/off/v1/knowledge-panel/?code=111111111,999999999")
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert "111111111" in response_data["panels"]
+    assert "999999999" in response_data["errors"]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_panels_batch_uses_cache(async_client: AsyncClient, sample_product_data: ProductData):
+    """Test that the batch endpoint reuses cache from previous calls"""
+    knowledge_panel_cache.clear()
+
+    mock_response_data = {"product": sample_product_data}
+    mock_response = AsyncMock()
+    mock_response.json = MagicMock(return_value=mock_response_data)
+    mock_response.raise_for_status = Mock(return_value=None)
+
+    with patch("app.business.open_food_facts.knowledge_panel.httpx.AsyncClient") as mock_http_client:
+        instance = mock_http_client.return_value.__aenter__.return_value
+        instance.get.return_value = mock_response
+
+        # First call - cache miss for both
+        response1 = await async_client.get("/off/v1/knowledge-panel/?code=111111111,222222222")
+        assert response1.status_code == 200
+        calls_after_first = instance.get.call_count
+
+        # Second call - cache hit for both, no new API calls expected
+        response2 = await async_client.get("/off/v1/knowledge-panel/?code=111111111,222222222")
+        assert response2.status_code == 200
+        assert instance.get.call_count == calls_after_first


### PR DESCRIPTION
## Description

Add a new batch knowledge panel endpoint supporting one or multiple barcodes in a single request.

The new route:

```text
GET /off/v1/knowledge-panel/?code=123,456
```

accepts comma-separated barcodes and returns a response indexed by barcode, with:

* `panels` for successful results
* `errors` for per-barcode failures

The existing single-product endpoint:

```text
/off/v1/knowledge-panel/{barcode}
```

is preserved for backward compatibility.

The implementation follows the API format discussed in the October GitHub mobile/Dart discussion:

* singular `/knowledge-panel/` route
* `code` query parameter
* comma-separated barcode format

`lang` handling is unchanged and still managed through the existing middleware.

`country` query parameters are currently ignored server-side (FastAPI ignores undeclared params), so there is no impact on the suffering calculation logic at the moment.

---

## Code changes

* Added batch endpoint:

  ```text
  GET /off/v1/knowledge-panel/?code=123,456
  ```

* Added parallel processing using `asyncio`

* Added batch response format:

  ```json
  {
    "panels": {
      "123": {...}
    },
    "errors": {
      "456": {...}
    }
  }
  ```

* Preserved existing single-barcode endpoint

* Added unit tests covering:

  * single barcode batch requests
  * multiple barcode batch requests
  * partial failures
  * cache reuse behavior

* Refactored OFF HTTP calls to reuse a shared `httpx.AsyncClient`
  instead of creating a new client per request

* Added retry handling for transient OFF API failures (`429`, network issues, etc.)

---

## How to test

You can test either through the OFF app or directly with `curl`.

### Existing endpoint regression test

```bash
curl "http://127.0.0.1:8000/off/v1/knowledge-panel/3017620422003?lang=fr"
```

### New batch endpoint with a single barcode

```bash
curl "http://127.0.0.1:8000/off/v1/knowledge-panel/?code=3017620422003&lang=fr"
```

### New batch endpoint with multiple barcodes

```bash
curl "http://127.0.0.1:8000/off/v1/knowledge-panel/?code=3017620422003,3228857000166&lang=fr"
```

### Batch endpoint with mixed success/failure cases

```bash
curl "http://127.0.0.1:8000/off/v1/knowledge-panel/?code=3017620422003,3450970045360&lang=fr"
```
